### PR TITLE
Name Attribute: name prefix for all methods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,39 @@ Route::get('my-prefix/my-get-route', [MyController::class, 'myGetMethod']);
 Route::post('my-prefix/my-post-route', [MyController::class, 'myPostMethod']);
 ```
 
+### Specifying a prefix name
+
+You can use the `Name` annotation on a class to prefix the name of all methods of that class (like name for route group).
+
+```php
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Post;
+use Spatie\RouteAttributes\Attributes\Name;
+
+#[Name('my-name.')]
+class MyController
+{
+    #[Get('my-get-route', name: 'my-get-route')]
+    public function myGetMethod()
+    {
+    }
+
+    #[Post('my-post-route')]
+    public function myPostMethod()
+    {
+    }
+}
+```
+
+These annotations will automatically register these routes:
+
+```php
+Route::name('my-name.')->group(function () {
+    Route::get('my-get-route', [MyController::class, 'myGetMethod'])->name('my-get-route');
+    Route::post('my-post-route', [MyController::class, 'myPostMethod']);
+});
+```
+
 ## Testing
 
 ``` bash

--- a/src/Attributes/Name.php
+++ b/src/Attributes/Name.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\RouteAttributes\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Name implements RouteAttribute
+{
+    public function __construct(
+        public $name
+    ) {}
+}

--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -4,6 +4,7 @@ namespace Spatie\RouteAttributes;
 
 use ReflectionClass;
 use Spatie\RouteAttributes\Attributes\Middleware;
+use Spatie\RouteAttributes\Attributes\Name;
 use Spatie\RouteAttributes\Attributes\Prefix;
 use Spatie\RouteAttributes\Attributes\RouteAttribute;
 
@@ -34,6 +35,16 @@ class ClassRouteAttributes
         }
 
         return $attribute->middleware;
+    }
+
+    public function name(): ?string
+    {
+        /** @var \Spatie\RouteAttributes\Attributes\Name $attribute */
+        if (! $attribute = $this->getAttribute(Name::class)) {
+            return null;
+        }
+
+        return $attribute->name;
     }
 
     protected function getAttribute(string $attributeClass): ?RouteAttribute

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -89,7 +89,7 @@ class RouteRegistrar
         $class = new ReflectionClass($className);
 
         $classRouteAttributes = new ClassRouteAttributes($class);
-        $namePrefix = $classRouteAttributes->name() ?? '';
+        $namePrefix = $classRouteAttributes->name();
 
         foreach ($class->getMethods() as $method) {
             $attributes = $method->getAttributes(RouteAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
@@ -112,8 +112,12 @@ class RouteRegistrar
                     /** @var \Illuminate\Routing\Route $route */
                     $route = $this->router->$httpMethod($attributeClass->uri, $action);
 
-                    $route
-                        ->name($namePrefix.$attributeClass->name);
+                    if (is_null($namePrefix)) {
+                        $route->name($attributeClass->name);
+                    } else {
+                        $route
+                            ->name($namePrefix.$attributeClass->name);
+                    }
 
                     if ($prefix = $classRouteAttributes->prefix()) {
                         $route->prefix($prefix);

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -89,6 +89,7 @@ class RouteRegistrar
         $class = new ReflectionClass($className);
 
         $classRouteAttributes = new ClassRouteAttributes($class);
+        $namePrefix = $classRouteAttributes->name() ?? '';
 
         foreach ($class->getMethods() as $method) {
             $attributes = $method->getAttributes(RouteAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
@@ -112,7 +113,7 @@ class RouteRegistrar
                     $route = $this->router->$httpMethod($attributeClass->uri, $action);
 
                     $route
-                        ->name($attributeClass->name);
+                        ->name($namePrefix.$attributeClass->name);
 
                     if ($prefix = $classRouteAttributes->prefix()) {
                         $route->prefix($prefix);

--- a/tests/AttributeTests/NameAttributeTest.php
+++ b/tests/AttributeTests/NameAttributeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\AttributeTests;
+
+use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\NameTestController;
+
+class NameAttributeTest extends TestCase
+{
+    /** @test */
+    public function it_can_apply_a_prefix_name_for_all_routes()
+    {
+        $this->routeRegistrar->registerClass(NameTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(
+                NameTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-get-method',
+                name: 'my-name.my-get-method',
+            )
+            ->assertRouteRegistered(
+                NameTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethod: 'post',
+                uri: 'my-post-method',
+                name: 'my-name.',
+            );
+    }
+}

--- a/tests/TestClasses/Controllers/NameTestController.php
+++ b/tests/TestClasses/Controllers/NameTestController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Name;
+use Spatie\RouteAttributes\Attributes\Post;
+
+#[Name('my-name.')]
+class NameTestController
+{
+    #[Get('my-get-method', name: 'my-get-method')]
+    public function myGetMethod()
+    {
+    }
+
+    #[Post('my-post-method')]
+    public function myPostMethod()
+    {
+    }
+}


### PR DESCRIPTION
My first PR on Github.
This annotation add name prefix for all methods in a class (like name for group routes)

Usage

```php
use Spatie\RouteAttributes\Attributes\Get;
use Spatie\RouteAttributes\Attributes\Post;
use Spatie\RouteAttributes\Attributes\Name;

#[Name('my-name.')]
class MyController
{
    #[Get('my-get-route', name: 'my-get-route')]
    public function myGetMethod()
    {
    }

    #[Post('my-post-route')]
    public function myPostMethod()
    {
    }
}
```

These annotations will automatically register these routes:

```php
Route::name('my-name.')->group(function () {
    Route::get('my-get-route', [MyController::class, 'myGetMethod'])->name('my-get-route');
    Route::post('my-post-route', [MyController::class, 'myPostMethod']);
});