### PR TITLE
Add missing config prefix to RouteAttributesServiceProvider.php

### DIFF
--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -30,6 +30,6 @@ class RouteAttributesServiceProvider extends ServiceProvider
 
         $routeRegistrar = new RouteRegistrar(app()->router);
 
-        collect(config('directories'))->each(fn (string $directory) => $routeRegistrar->registerDirectory($directory));
+        collect(config('route-attributes.directories'))->each(fn (string $directory) => $routeRegistrar->registerDirectory($directory));
     }
 }

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\RouteAttributes;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 
 class RouteAttributesServiceProvider extends ServiceProvider
@@ -28,8 +29,11 @@ class RouteAttributesServiceProvider extends ServiceProvider
             return;
         }
 
-        $routeRegistrar = new RouteRegistrar(app()->router);
+        $routeRegistrar = (new RouteRegistrar(app()->router))
+            ->useRootNamespace(app()->getNamespace());
 
-        collect(config('route-attributes.directories'))->each(fn (string $directory) => $routeRegistrar->registerDirectory($directory));
+        $testClassDirectory = __DIR__ . '/../tests/TestClasses';
+
+        collect(app()->runningUnitTests() ? $testClassDirectory : config('route-attributes.directories'))->each(fn (string $directory) => $routeRegistrar->registerDirectory($directory));
     }
 }


### PR DESCRIPTION
In #8 's pull request I noticed there was a missing config field that wasn't actually registering routes at an application level. This PR fixes that but does not add the route root namespace to avoid merging two separate issues.