### PR TITLE
Applying selected middlewares to all routes feature implemented.

### DIFF
--- a/config/route-attributes.php
+++ b/config/route-attributes.php
@@ -13,4 +13,11 @@ return [
     'directories' => [
         app_path('Http/Controllers'),
     ],
+
+    /**
+     * This middlewares will be applied to all routes.
+     */
+    'middlewares' => [
+        \Illuminate\Routing\Middleware\SubstituteBindings::class
+    ]
 ];

--- a/config/route-attributes.php
+++ b/config/route-attributes.php
@@ -15,7 +15,7 @@ return [
     ],
 
     /**
-     * This middlewares will be applied to all routes.
+     * This middleware will be applied to all routes.
      */
     'middlewares' => [
         \Illuminate\Routing\Middleware\SubstituteBindings::class

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -29,7 +29,8 @@ class RouteAttributesServiceProvider extends ServiceProvider
         }
 
         $routeRegistrar = (new RouteRegistrar(app()->router))
-            ->useRootNamespace(app()->getNamespace());
+            ->useRootNamespace(app()->getNamespace())
+            ->useMiddlewares(config('route-attributes.middlewares') ?? []);
 
         $testClassDirectory = __DIR__ . '/../tests/TestClasses';
 

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -21,6 +21,8 @@ class RouteRegistrar
 
     private string $rootNamespace;
 
+    private array $middlewares = [];
+
     public function __construct(Router $router)
     {
         $this->router = $router;
@@ -38,6 +40,13 @@ class RouteRegistrar
     public function useRootNamespace(string $rootNamespace): self
     {
         $this->rootNamespace = $rootNamespace;
+
+        return $this;
+    }
+
+    public function useMiddlewares(array $middlewares): self
+    {
+        $this->middlewares =  $middlewares;
 
         return $this;
     }
@@ -65,6 +74,11 @@ class RouteRegistrar
     public function registerClass(string $class): void
     {
         $this->processAttributes($class);
+    }
+
+    public function getMiddlewares(): array
+    {
+        return $this->middlewares ?? [];
     }
 
     protected function fullQualifiedClassNameFromFile(SplFileInfo $file): string
@@ -126,8 +140,7 @@ class RouteRegistrar
 
                 $classMiddleware = $classRouteAttributes->middleware();
                 $methodMiddleware = $attributeClass->middleware;
-
-                $route->middleware([...$classMiddleware, ...$methodMiddleware]);
+                $route->middleware([...$classMiddleware, ...$methodMiddleware, ...$this->middlewares]);
             }
         }
     }

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -5,6 +5,7 @@ namespace Spatie\RouteAttributes\Tests;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestFirstController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestSecondController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\SubDirectory\RegistrarTestControllerInSubDirectory;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
 
 class RouteRegistrarTest extends TestCase
 {
@@ -20,6 +21,22 @@ class RouteRegistrarTest extends TestCase
         $this->assertRouteRegistered(
             RegistrarTestFirstController::class,
             uri: 'first-method',
+        );
+    }
+
+    /** @test */
+    public function the_registrar_can_apply_config_middlewares_to_all_routes()
+    {
+        $this
+            ->routeRegistrar
+            ->registerFile($this->getTestPath('TestClasses/Controllers/RouteRegistrar/RegistrarTestFirstController.php'));
+
+        $this->assertRegisteredRoutesCount(1);
+
+        $this->assertRouteRegistered(
+            RegistrarTestFirstController::class,
+            uri: 'first-method',middleware: [AnotherTestMiddleware::class]
+
         );
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,8 @@ use Illuminate\Routing\RouteCollection;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\RouteAttributes\RouteAttributesServiceProvider;
 use Spatie\RouteAttributes\RouteRegistrar;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 
 class TestCase extends Orchestra
 {
@@ -21,6 +23,7 @@ class TestCase extends Orchestra
 
         $this->routeRegistrar = (new RouteRegistrar($router))
             ->useBasePath($this->getTestPath())
+            ->useMiddlewares([AnotherTestMiddleware::class])
             ->useRootNamespace('Spatie\RouteAttributes\Tests\\');
     }
 
@@ -76,7 +79,7 @@ class TestCase extends Orchestra
                     return false;
                 }
 
-                if (array_diff($route->middleware(), $middleware)) {
+                if (array_diff($route->middleware(), array_merge($middleware, $this->routeRegistrar->getMiddlewares()))) {
                     return false;
                 }
 

--- a/tests/TestClasses/Middleware/AnotherTestMiddleware.php
+++ b/tests/TestClasses/Middleware/AnotherTestMiddleware.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Middleware;
+
+
+use Closure;
+use Illuminate\Http\Request;
+
+class AnotherTestMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Middlewares like \Illuminate\Routing\Middleware\SubstituteBindings::class, are used for all routes. With current version of route attributes you cannot apply a middleware to all routes.

I added a field to route-attributes.php named `middlewares`, with this field you can add middlewares that will be applied to all routes.

This also fixes #13 , because SubstituteBindings middleware is comes default in config file.