### PR TITLE
Add new check to make sure TestClasses directory exists when running tests

### DIFF
--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -24,7 +24,7 @@ class RouteAttributesServiceProvider extends ServiceProvider
 
     protected function registerRoutes(): void
     {
-        if (! config('route-attributes.enabled')) {
+        if (!config('route-attributes.enabled')) {
             return;
         }
 
@@ -32,9 +32,13 @@ class RouteAttributesServiceProvider extends ServiceProvider
             ->useRootNamespace(app()->getNamespace())
             ->useMiddleware(config('route-attributes.middleware') ?? []);
 
-        $testClassDirectory = __DIR__ . '/../tests/TestClasses';
-        $routeDirectories = app()->runningUnitTests() && file_exists($testClassDirectory) ? $testClassDirectory : config('route-attributes.directories');
+        collect($this->getRouteDirectories())->each(fn(string $directory) => $routeRegistrar->registerDirectory($directory));
+    }
 
-        collect($routeDirectories)->each(fn (string $directory) => $routeRegistrar->registerDirectory($directory));
+    private function getRouteDirectories()
+    {
+        $testClassDirectory = __DIR__ . '/../tests/TestClasses';
+
+        return app()->runningUnitTests() && file_exists($testClassDirectory) ? $testClassDirectory : config('route-attributes.directories');
     }
 }

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -35,10 +35,10 @@ class RouteAttributesServiceProvider extends ServiceProvider
         collect($this->getRouteDirectories())->each(fn(string $directory) => $routeRegistrar->registerDirectory($directory));
     }
 
-    private function getRouteDirectories()
+    private function getRouteDirectories(): array
     {
         $testClassDirectory = __DIR__ . '/../tests/TestClasses';
 
-        return app()->runningUnitTests() && file_exists($testClassDirectory) ? $testClassDirectory : config('route-attributes.directories');
+        return app()->runningUnitTests() && file_exists($testClassDirectory) ? (array)$testClassDirectory : config('route-attributes.directories');
     }
 }

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -33,7 +33,8 @@ class RouteAttributesServiceProvider extends ServiceProvider
             ->useMiddleware(config('route-attributes.middleware') ?? []);
 
         $testClassDirectory = __DIR__ . '/../tests/TestClasses';
+        $routeDirectories = app()->runningUnitTests() && file_exists($testClassDirectory) ? $testClassDirectory : config('route-attributes.directories');
 
-        collect(app()->runningUnitTests() ? $testClassDirectory : config('route-attributes.directories'))->each(fn (string $directory) => $routeRegistrar->registerDirectory($directory));
+        collect($routeDirectories)->each(fn (string $directory) => $routeRegistrar->registerDirectory($directory));
     }
 }

--- a/tests/AttributeTests/MiddlewareAttributeTest.php
+++ b/tests/AttributeTests/MiddlewareAttributeTest.php
@@ -3,30 +3,30 @@
 namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
-use Spatie\RouteAttributes\Tests\TestClasses\Controllers\middlewareTestController;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestmiddleware;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\Testmiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\MiddlewareTestController;
+use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\middleware\TestMiddleware;
 
 class MiddlewareAttributeTest extends TestCase
 {
     /** @test */
     public function it_can_apply_middleware_on_each_method_of_a_controller()
     {
-        $this->routeRegistrar->registerClass(middlewareTestController::class);
+        $this->routeRegistrar->registerClass(MiddlewareTestController::class);
 
         $this
             ->assertRegisteredRoutesCount(2)
             ->assertRouteRegistered(
-                middlewareTestController::class,
+                MiddlewareTestController::class,
                 controllerMethod: 'singlemiddleware',
                 uri: 'single-middleware',
-                middleware: [Testmiddleware::class],
+                middleware: [TestMiddleware::class],
             )
             ->assertRouteRegistered(
-                middlewareTestController::class,
+                MiddlewareTestController::class,
                 controllerMethod: 'multiplemiddleware',
                 uri: 'multiple-middleware',
-                middleware: [Testmiddleware::class, OtherTestmiddleware::class],
+                middleware: [TestMiddleware::class, OtherTestMiddleware::class],
             );
     }
 }

--- a/tests/AttributeTests/MiddlewareAttributeTest.php
+++ b/tests/AttributeTests/MiddlewareAttributeTest.php
@@ -7,7 +7,7 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\middlewareTestControlle
 use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestmiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\middleware\Testmiddleware;
 
-class middlewareAttributeTest extends TestCase
+class MiddlewareAttributeTest extends TestCase
 {
     /** @test */
     public function it_can_apply_middleware_on_each_method_of_a_controller()

--- a/tests/AttributeTests/MiddlewareAttributeTest.php
+++ b/tests/AttributeTests/MiddlewareAttributeTest.php
@@ -4,8 +4,8 @@ namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\MiddlewareTestController;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestMiddleware;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\TestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
 class MiddlewareAttributeTest extends TestCase
 {
@@ -18,13 +18,13 @@ class MiddlewareAttributeTest extends TestCase
             ->assertRegisteredRoutesCount(2)
             ->assertRouteRegistered(
                 MiddlewareTestController::class,
-                controllerMethod: 'singlemiddleware',
+                controllerMethod: 'singleMiddleware',
                 uri: 'single-middleware',
                 middleware: [TestMiddleware::class],
             )
             ->assertRouteRegistered(
                 MiddlewareTestController::class,
-                controllerMethod: 'multiplemiddleware',
+                controllerMethod: 'multipleMiddleware',
                 uri: 'multiple-middleware',
                 middleware: [TestMiddleware::class, OtherTestMiddleware::class],
             );

--- a/tests/AttributeTests/RouteAttributeTest.php
+++ b/tests/AttributeTests/RouteAttributeTest.php
@@ -9,7 +9,7 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteGet
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RoutemiddlewareTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RoutePostTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteNameTestController;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\Testmiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\middleware\TestMiddleware;
 
 class RouteAttributeTest extends TestCase
 {
@@ -42,7 +42,7 @@ class RouteAttributeTest extends TestCase
 
         $this->assertRouteRegistered(
             controller: RoutemiddlewareTestController::class,
-            middleware: Testmiddleware::class,
+            middleware: TestMiddleware::class,
         );
     }
 

--- a/tests/AttributeTests/RouteAttributeTest.php
+++ b/tests/AttributeTests/RouteAttributeTest.php
@@ -6,10 +6,10 @@ use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\RouteRegistrar;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\InvokableRouteGetTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteGetTestController;
-use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RoutemiddlewareTestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteMiddlewareTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RoutePostTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteNameTestController;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\TestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
 class RouteAttributeTest extends TestCase
 {
@@ -38,10 +38,10 @@ class RouteAttributeTest extends TestCase
     /** @test */
     public function it_can_add_middleware_to_a_method()
     {
-        $this->routeRegistrar->registerClass(RoutemiddlewareTestController::class);
+        $this->routeRegistrar->registerClass(RouteMiddlewareTestController::class);
 
         $this->assertRouteRegistered(
-            controller: RoutemiddlewareTestController::class,
+            controller: RouteMiddlewareTestController::class,
             middleware: TestMiddleware::class,
         );
     }

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -5,7 +5,7 @@ namespace Spatie\RouteAttributes\Tests;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestFirstController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestSecondController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\SubDirectory\RegistrarTestControllerInSubDirectory;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\AnotherTestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
 
 class RouteRegistrarTest extends TestCase
 {
@@ -35,8 +35,8 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertRouteRegistered(
             RegistrarTestFirstController::class,
-            uri: 'first-method',middleware: [AnotherTestMiddleware::class]
-
+            uri: 'first-method',
+            middleware: [AnotherTestMiddleware::class]
         );
     }
 

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -5,7 +5,7 @@ namespace Spatie\RouteAttributes\Tests;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestFirstController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestSecondController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\SubDirectory\RegistrarTestControllerInSubDirectory;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\AnotherTestmiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\middleware\AnotherTestMiddleware;
 
 class RouteRegistrarTest extends TestCase
 {
@@ -35,7 +35,7 @@ class RouteRegistrarTest extends TestCase
 
         $this->assertRouteRegistered(
             RegistrarTestFirstController::class,
-            uri: 'first-method',middleware: [AnotherTestmiddleware::class]
+            uri: 'first-method',middleware: [AnotherTestMiddleware::class]
 
         );
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,8 +8,8 @@ use Illuminate\Routing\RouteCollection;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\RouteAttributes\RouteAttributesServiceProvider;
 use Spatie\RouteAttributes\RouteRegistrar;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\AnotherTestmiddleware;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestmiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\middleware\AnotherTestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestMiddleware;
 
 class TestCase extends Orchestra
 {
@@ -23,7 +23,7 @@ class TestCase extends Orchestra
 
         $this->routeRegistrar = (new RouteRegistrar($router))
             ->useBasePath($this->getTestPath())
-            ->useMiddleware([AnotherTestmiddleware::class])
+            ->useMiddleware([AnotherTestMiddleware::class])
             ->useRootNamespace('Spatie\RouteAttributes\Tests\\');
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,14 +2,13 @@
 
 namespace Spatie\RouteAttributes\Tests;
 
-use Arr;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Arr;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\RouteAttributes\RouteAttributesServiceProvider;
 use Spatie\RouteAttributes\RouteRegistrar;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\AnotherTestMiddleware;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
 
 class TestCase extends Orchestra
 {

--- a/tests/TestClasses/Controllers/MiddlewareTestController.php
+++ b/tests/TestClasses/Controllers/MiddlewareTestController.php
@@ -4,18 +4,18 @@ namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
 
 use Spatie\RouteAttributes\Attributes\middleware;
 use Spatie\RouteAttributes\Attributes\Route;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestmiddleware;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\Testmiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\middleware\TestMiddleware;
 
-#[middleware(Testmiddleware::class)]
-class middlewareTestController
+#[middleware(TestMiddleware::class)]
+class MiddlewareTestController
 {
     #[Route('get', 'single-middleware')]
     public function singlemiddleware()
     {
     }
 
-    #[Route('get', 'multiple-middleware', middleware: OtherTestmiddleware::class)]
+    #[Route('get', 'multiple-middleware', middleware: OtherTestMiddleware::class)]
     public function multiplemiddleware()
     {
     }

--- a/tests/TestClasses/Controllers/MiddlewareTestController.php
+++ b/tests/TestClasses/Controllers/MiddlewareTestController.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
 
-use Spatie\RouteAttributes\Attributes\middleware;
+use Spatie\RouteAttributes\Attributes\Middleware;
 use Spatie\RouteAttributes\Attributes\Route;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;

--- a/tests/TestClasses/Controllers/MiddlewareTestController.php
+++ b/tests/TestClasses/Controllers/MiddlewareTestController.php
@@ -4,19 +4,19 @@ namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
 
 use Spatie\RouteAttributes\Attributes\middleware;
 use Spatie\RouteAttributes\Attributes\Route;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\OtherTestMiddleware;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\TestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
-#[middleware(TestMiddleware::class)]
+#[Middleware(TestMiddleware::class)]
 class MiddlewareTestController
 {
     #[Route('get', 'single-middleware')]
-    public function singlemiddleware()
+    public function singleMiddleware()
     {
     }
 
     #[Route('get', 'multiple-middleware', middleware: OtherTestMiddleware::class)]
-    public function multiplemiddleware()
+    public function multipleMiddleware()
     {
     }
 }

--- a/tests/TestClasses/Controllers/RouteAttribute/RouteMiddlewareTestController.php
+++ b/tests/TestClasses/Controllers/RouteAttribute/RouteMiddlewareTestController.php
@@ -5,7 +5,7 @@ namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute;
 use Spatie\RouteAttributes\Attributes\Route;
 use Spatie\RouteAttributes\Tests\TestClasses\middleware\Testmiddleware;
 
-class RoutemiddlewareTestController
+class RouteMiddlewareTestController
 {
     #[Route('get', 'my-method', middleware: Testmiddleware::class)]
     public function myMethod()

--- a/tests/TestClasses/Controllers/RouteAttribute/RouteMiddlewareTestController.php
+++ b/tests/TestClasses/Controllers/RouteAttribute/RouteMiddlewareTestController.php
@@ -3,7 +3,7 @@
 namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute;
 
 use Spatie\RouteAttributes\Attributes\Route;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\TestMiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
 class RouteMiddlewareTestController
 {

--- a/tests/TestClasses/Controllers/RouteAttribute/RouteMiddlewareTestController.php
+++ b/tests/TestClasses/Controllers/RouteAttribute/RouteMiddlewareTestController.php
@@ -3,11 +3,11 @@
 namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute;
 
 use Spatie\RouteAttributes\Attributes\Route;
-use Spatie\RouteAttributes\Tests\TestClasses\middleware\Testmiddleware;
+use Spatie\RouteAttributes\Tests\TestClasses\middleware\TestMiddleware;
 
 class RouteMiddlewareTestController
 {
-    #[Route('get', 'my-method', middleware: Testmiddleware::class)]
+    #[Route('get', 'my-method', middleware: TestMiddleware::class)]
     public function myMethod()
     {
     }

--- a/tests/TestClasses/Middleware/AnotherTestMiddleware.php
+++ b/tests/TestClasses/Middleware/AnotherTestMiddleware.php
@@ -1,12 +1,12 @@
 <?php
 
 
-namespace Spatie\RouteAttributes\Tests\TestClasses\middleware;
+namespace Spatie\RouteAttributes\Tests\TestClasses\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
 
-class AnotherTestmiddleware
+class AnotherTestMiddleware
 {
     public function handle(Request $request, Closure $next)
     {

--- a/tests/TestClasses/Middleware/OtherTestMiddleware.php
+++ b/tests/TestClasses/Middleware/OtherTestMiddleware.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\TestClasses\middleware;
+namespace Spatie\RouteAttributes\Tests\TestClasses\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
 
-class OtherTestmiddleware
+class OtherTestMiddleware
 {
     public function handle(Request $request, Closure $next)
     {

--- a/tests/TestClasses/Middleware/TestMiddleware.php
+++ b/tests/TestClasses/Middleware/TestMiddleware.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\TestClasses\middleware;
+namespace Spatie\RouteAttributes\Tests\TestClasses\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
 
-class Testmiddleware
+class TestMiddleware
 {
     public function handle(Request $request, Closure $next)
     {


### PR DESCRIPTION
This PR aims to fix the following error when running integration tests:

`DirectoryNotFoundException: src/../tests/TestClasses" directory does not exist.`

This happens because the package tries to use the `TestClasses` directory even though is doesn't exists when running tests in a real Laravel application.