### PR TITLE
Change approach to handle routes with prefix

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -104,6 +104,12 @@ class RouteRegistrar
 
         $classRouteAttributes = new ClassRouteAttributes($class);
 
+        ($prefix = $classRouteAttributes->prefix())
+            ? $this->router->prefix($prefix)->group(fn() => $this->registerRoutes($class, $classRouteAttributes))
+            : $this->registerRoutes($class, $classRouteAttributes);
+    }
+
+    protected function registerRoutes(ReflectionClass $class, ClassRouteAttributes $classRouteAttributes): void {
         foreach ($class->getMethods() as $method) {
             $attributes = $method->getAttributes(RouteAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
 
@@ -132,10 +138,6 @@ class RouteRegistrar
 
                 if ($domain = $classRouteAttributes->domain()) {
                     $route->domain($domain);
-                }
-
-                if ($prefix = $classRouteAttributes->prefix()) {
-                    $route->prefix($prefix);
                 }
 
                 $classMiddleware = $classRouteAttributes->middleware();

--- a/tests/AttributeTests/PrefixAttributeTest.php
+++ b/tests/AttributeTests/PrefixAttributeTest.php
@@ -13,7 +13,12 @@ class PrefixAttributeTest extends TestCase
         $this->routeRegistrar->registerClass(PrefixTestController::class);
 
         $this
-            ->assertRegisteredRoutesCount(2)
+            ->assertRegisteredRoutesCount(3)
+            ->assertRouteRegistered(
+                PrefixTestController::class,
+                controllerMethod: 'myRootGetMethod',
+                uri: 'my-prefix',
+            )
             ->assertRouteRegistered(
                 PrefixTestController::class,
                 controllerMethod: 'myGetMethod',

--- a/tests/TestClasses/Controllers/PrefixTestController.php
+++ b/tests/TestClasses/Controllers/PrefixTestController.php
@@ -9,6 +9,11 @@ use Spatie\RouteAttributes\Attributes\Prefix;
 #[Prefix('my-prefix')]
 class PrefixTestController
 {
+    #[Get('/')]
+    public function myRootGetMethod()
+    {
+    }
+
     #[Get('my-get-method')]
     public function myGetMethod()
     {


### PR DESCRIPTION
This PR aims to fix an edge case with the current implementation of `#[Prefix]`, currently the routes are registered first and then the prefix is applied, which leads to an error when registering nested root routes e.g. `#[Get("/")]`.

The new approach proposed in this PR follows the implementation described in the Laravel official docs.
https://laravel.com/docs/8.x/routing#route-group-prefixes

Feel free to ask me to change anything or to propose another way of fixing the issue.

Also, I would like to point out something about how the tests verify the routes were correctly registered.
https://github.com/spatie/laravel-route-attributes/blob/master/tests/TestCase.php#L63

Even though this approach works for the majority of cases, it's not how Laravel matches routes internally, which could lead to false-positives, and this is exactly the scenario this PR intends to fix. If you run the new added test case with the old implementation, the test will pass, however if you run an integration test that actually goes through Laravel matching algorithm, it will fail. 

Ideally, we should change the implementation to use the same matching algorithm Laravel uses.