### PR TITLE
Global middleware from config file should be registered first

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -143,7 +143,7 @@ class RouteRegistrar
 
                 $classMiddleware = $classRouteAttributes->middleware();
                 $methodMiddleware = $attributeClass->middleware;
-                $route->middleware([...$classMiddleware, ...$methodMiddleware, ...$this->middleware]);
+                $route->middleware([...$this->middleware, ...$classMiddleware, ...$methodMiddleware]);
             }
         }
     }


### PR DESCRIPTION
For example:
If config file (route-attribute.php) has:
 // This middleware will be applied to all routes.
    'middleware' => [
        'web',
    ],

And Controller has:
#[Get('/dashboard'), middleware: ['auth'])

It will always redirect to /login, because auth middleware was registered before web middleware