### PR TITLE
route-registrar: reflection method name for invoke

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -127,7 +127,7 @@ class RouteRegistrar
 
                 $httpMethod = $attributeClass->method;
 
-                $action = $attributeClass->method === '__invoke'
+                $action = $method->getName() === '__invoke'
                     ? $class->getName()
                     : [$class->getName(), $method->getName()];
 

--- a/tests/AttributeTests/RouteAttributeTest.php
+++ b/tests/AttributeTests/RouteAttributeTest.php
@@ -66,7 +66,7 @@ class RouteAttributeTest extends TestCase
             ->assertRegisteredRoutesCount(1)
             ->assertRouteRegistered(
                 controller: InvokableRouteGetTestController::class,
-                controllerMethod: '__invoke',
+                controllerMethod: InvokableRouteGetTestController::class,
                 uri: 'my-invokable-route'
             );
     }


### PR DESCRIPTION
This corrects invokable controller detection by referencing the reflection method’s name instead of the attribute class’ method. This does not cause any behaviour changes, as `Controller@__invoke` is the same as `Controller`, at least in terms of the outcome.