### PR TITLE
Added possibility to register multiple verbs for a route

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ We have left no HTTP verb behind. You can use these attributes on controller met
 #[Spatie\RouteAttributes\Attributes\Options('my-uri')]
 ```
 
+### Using multiple verbs
+
+To register a route for all verbs, you can use the `Any` attribute:
+
+```php
+#[Spatie\RouteAttributes\Attributes\Any('my-uri')]
+```
+
+To register a route for a few verbs at once, you can use the `Route` attribute directly:
+
+```php
+#[Spatie\RouteAttributes\Attributes\Route(['put', 'patch'], 'my-uri')]
+```
+
 ### Specify a route name
 
 All HTTP verb attributes accept a parameter named `name` that accepts a route name.

--- a/src/Attributes/Any.php
+++ b/src/Attributes/Any.php
@@ -3,6 +3,7 @@
 namespace Spatie\RouteAttributes\Attributes;
 
 use Attribute;
+use Illuminate\Routing\Router;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class Any extends Route
@@ -13,7 +14,7 @@ class Any extends Route
         array | string $middleware = [],
     ) {
         parent::__construct(
-            method: 'any',
+            methods: Router::$verbs,
             uri: $uri,
             name: $name,
             middleware: $middleware,

--- a/src/Attributes/Delete.php
+++ b/src/Attributes/Delete.php
@@ -13,7 +13,7 @@ class Delete extends Route
         array | string $middleware = [],
     ) {
         parent::__construct(
-            method: 'delete',
+            methods: ['delete'],
             uri: $uri,
             name: $name,
             middleware: $middleware,

--- a/src/Attributes/Get.php
+++ b/src/Attributes/Get.php
@@ -13,7 +13,7 @@ class Get extends Route
         array | string $middleware = [],
     ) {
         parent::__construct(
-            method: 'get',
+            methods: ['get'],
             uri: $uri,
             name: $name,
             middleware: $middleware,

--- a/src/Attributes/Options.php
+++ b/src/Attributes/Options.php
@@ -13,7 +13,7 @@ class Options extends Route
         array | string $middleware = [],
     ) {
         parent::__construct(
-            method: 'options',
+            methods: ['options'],
             uri: $uri,
             name: $name,
             middleware: $middleware,

--- a/src/Attributes/Patch.php
+++ b/src/Attributes/Patch.php
@@ -13,7 +13,7 @@ class Patch extends Route
         array | string $middleware = [],
     ) {
         parent::__construct(
-            method: 'patch',
+            methods: ['patch'],
             uri: $uri,
             name: $name,
             middleware: $middleware,

--- a/src/Attributes/Post.php
+++ b/src/Attributes/Post.php
@@ -13,7 +13,7 @@ class Post extends Route
         array | string $middleware = [],
     ) {
         parent::__construct(
-            method: 'post',
+            methods: ['post'],
             uri: $uri,
             name: $name,
             middleware: $middleware,

--- a/src/Attributes/Put.php
+++ b/src/Attributes/Put.php
@@ -13,7 +13,7 @@ class Put extends Route
         array | string $middleware = [],
     ) {
         parent::__construct(
-            method: 'put',
+            methods: ['put'],
             uri: $uri,
             name: $name,
             middleware: $middleware,

--- a/src/Attributes/Route.php
+++ b/src/Attributes/Route.php
@@ -3,19 +3,30 @@
 namespace Spatie\RouteAttributes\Attributes;
 
 use Attribute;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class Route implements RouteAttribute
 {
+    public array $methods;
+
     public array $middleware;
 
     public function __construct(
-        public string $method,
+        array | string $methods,
         public string $uri,
         public ?string $name = null,
         array | string $middleware = [],
     ) {
+        $this->methods = array_map(static fn(string $verb) => in_array(
+                $upperVerb = strtoupper($verb),
+                Router::$verbs
+            )
+            ? $upperVerb
+            : $verb,
+            Arr::wrap($methods)
+        );
         $this->middleware = Arr::wrap($middleware);
     }
 }

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -125,14 +125,13 @@ class RouteRegistrar
                     continue;
                 }
 
-                $httpMethod = $attributeClass->method;
+                $httpMethods = $attributeClass->methods;
 
-                $action = $attributeClass->method === '__invoke'
+                $action = in_array('__invoke', $attributeClass->methods)
                     ? $class->getName()
                     : [$class->getName(), $method->getName()];
 
-                /** @var \Illuminate\Routing\Route $route */
-                $route = $this->router->$httpMethod($attributeClass->uri, $action);
+                $route = $this->router->addRoute($httpMethods, $attributeClass->uri, $action);
 
                 $route
                     ->name($attributeClass->name);

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -127,7 +127,7 @@ class RouteRegistrar
 
                 $httpMethods = $attributeClass->methods;
 
-                $action = in_array('__invoke', $attributeClass->methods)
+                $action = $method->getName() === '__invoke'
                     ? $class->getName()
                     : [$class->getName(), $method->getName()];
 

--- a/tests/AttributeTests/DomainAttributeTest.php
+++ b/tests/AttributeTests/DomainAttributeTest.php
@@ -23,7 +23,7 @@ class DomainAttributeTest extends TestCase
             ->assertRouteRegistered(
                 DomainTestController::class,
                 controllerMethod: 'myPostMethod',
-                httpMethod: 'post',
+                httpMethods: 'post',
                 uri: 'my-post-method',
                 domain: 'my-subdomain.localhost'
             );

--- a/tests/AttributeTests/PrefixAttributeTest.php
+++ b/tests/AttributeTests/PrefixAttributeTest.php
@@ -27,7 +27,7 @@ class PrefixAttributeTest extends TestCase
             ->assertRouteRegistered(
                 PrefixTestController::class,
                 controllerMethod: 'myPostMethod',
-                httpMethod: 'post',
+                httpMethods: 'post',
                 uri: 'my-prefix/my-post-method',
             );
     }

--- a/tests/AttributeTests/RouteAttributeTest.php
+++ b/tests/AttributeTests/RouteAttributeTest.php
@@ -7,6 +7,7 @@ use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\InvokableRouteGetTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteGetTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteMiddlewareTestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteMultiVerbTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteNameTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RoutePostTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
@@ -33,6 +34,21 @@ class RouteAttributeTest extends TestCase
         $this
             ->assertRegisteredRoutesCount(1)
             ->assertRouteRegistered(RoutePostTestController::class, 'myPostMethod', 'post', 'my-post-method');
+    }
+
+    /** @test */
+    public function the_route_annotation_can_register_a_multi_verb_route()
+    {
+        $this->routeRegistrar->registerClass(RouteMultiVerbTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(1)
+            ->assertRouteRegistered(
+                RouteMultiVerbTestController::class,
+                'myMultiVerbMethod',
+                ['get','post', 'delete'],
+                'my-multi-verb-method'
+            );
     }
 
     /** @test */

--- a/tests/AttributeTests/RouteAttributeTest.php
+++ b/tests/AttributeTests/RouteAttributeTest.php
@@ -82,7 +82,7 @@ class RouteAttributeTest extends TestCase
             ->assertRegisteredRoutesCount(1)
             ->assertRouteRegistered(
                 controller: InvokableRouteGetTestController::class,
-                controllerMethod: '__invoke',
+                controllerMethod: InvokableRouteGetTestController::class,
                 uri: 'my-invokable-route'
             );
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,7 +50,7 @@ class TestCase extends Orchestra
     public function assertRouteRegistered(
         string $controller,
         string $controllerMethod = 'myMethod',
-        string $httpMethod = 'get',
+        string | array $httpMethods = ['get'],
         string $uri = 'my-method',
         string | array $middleware = [],
         ?string $name = null,
@@ -61,9 +61,11 @@ class TestCase extends Orchestra
         }
 
         $routeRegistered = collect($this->getRouteCollection()->getRoutes())
-            ->contains(function (Route $route) use ($name, $middleware, $controllerMethod, $controller, $uri, $httpMethod, $domain) {
-                if (! in_array(strtoupper($httpMethod), $route->methods)) {
-                    return false;
+            ->contains(function (Route $route) use ($name, $middleware, $controllerMethod, $controller, $uri, $httpMethods, $domain) {
+                foreach (Arr::wrap($httpMethods) as $httpMethod) {
+                    if (! in_array(strtoupper($httpMethod), $route->methods)) {
+                        return false;
+                    }
                 }
 
                 if ($route->uri() !== $uri) {

--- a/tests/TestClasses/Controllers/RouteAttribute/RouteMultiVerbTestController.php
+++ b/tests/TestClasses/Controllers/RouteAttribute/RouteMultiVerbTestController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute;
+
+use Spatie\RouteAttributes\Attributes\Route;
+
+class RouteMultiVerbTestController
+{
+    #[Route(['get', 'post', 'delete'], 'my-multi-verb-method')]
+    public function myMultiVerbMethod()
+    {
+    }
+}


### PR DESCRIPTION
This PR adds support for registering routes with multiple verbs, which comes in handy at times. Essentially, I just widened the `method` parameter of the `Route` attribute to accept an array of verbs - everything else is just a consequence of that modification. 

The most complex part is uppercasing common HTTP methods, as they are case-sensitive per [RFC 7231](https://tools.ietf.org/html/rfc7231#section-4.1), so to not break existing implementations and keep the convenience of `Route('get')`, all methods [exposed by the Laravel router](https://github.com/laravel/framework/blob/81ef9850cc388f2f92b868fb35ffb76f0c9a0f46/src/Illuminate/Routing/Router.php#L122) will be converted to uppercase.

This PR does not contain any breaking changes.