### PR TITLE
Add additional functionality to get domain from a config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,40 @@ Route::get('my-get-route', [MyController::class, 'myGetMethod'])->domain('my-sub
 Route::post('my-post-route', [MyController::class, 'myPostMethod'])->domain('my-subdomain.localhost');
 ```
 
+### Specifying a domain from a config key
+
+There maybe a need to define a domain from a configuration file, for example where
+your subdomain will be different on your development environment to your production environment.
+
+```
+config/domains.php
+
+return [
+    'main' => env('SITE_URL', 'example.com'),
+    'subdomain' => env('SUBDOMAIN_URL', 'subdomain.exmaple.com')
+];
+```
+
+```php
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Post;
+use Spatie\RouteAttributes\Attributes\DomainFromConfig;
+
+#[DomainFromConfig('domains.main')]
+class MyController
+{
+    #[Get('my-get-route')]
+    public function myGetMethod()
+    {
+    }
+}
+```
+When this is parsed, it will get the value of `domains.main` from the config file and 
+register the route as follows;
+
+```php
+Route::get('my-get-route', [MyController::class, 'myGetMethod'])->domain('example.com');
+```
 
 ### Specifying wheres
 

--- a/src/Attributes/DomainFromConfig.php
+++ b/src/Attributes/DomainFromConfig.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class DomainFromConfig implements RouteAttribute
+{
+    public function __construct(
+        public string $domain
+    ) {
+    }
+}

--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -4,6 +4,7 @@ namespace Spatie\RouteAttributes;
 
 use ReflectionClass;
 use Spatie\RouteAttributes\Attributes\Domain;
+use Spatie\RouteAttributes\Attributes\DomainFromConfig;
 use Spatie\RouteAttributes\Attributes\Middleware;
 use Spatie\RouteAttributes\Attributes\Prefix;
 use Spatie\RouteAttributes\Attributes\Resource;
@@ -43,6 +44,19 @@ class ClassRouteAttributes
         }
 
         return $attribute->domain;
+    }
+
+    /**
+     * @psalm-suppress NoInterfaceProperties
+     */
+    public function domainFromConfig(): ?string
+    {
+        /** @var \Spatie\RouteAttributes\Attributes\DomainFromConfig $attribute */
+        if (! $attribute = $this->getAttribute(DomainFromConfig::class)) {
+            return null;
+        }
+
+        return config($attribute->domain);
     }
 
     /**

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -167,7 +167,9 @@ class RouteRegistrar
                 $route
                     ->name($attributeClass->name);
 
-                if ($domain = $classRouteAttributes->domain()) {
+                if ($domain = $classRouteAttributes->domainFromConfig()) {
+                    $route->domain($domain);
+                } else if ($domain = $classRouteAttributes->domain()) {
                     $route->domain($domain);
                 }
 

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -46,7 +46,7 @@ class RouteRegistrar
         return $this;
     }
 
-    public function useMiddleware(string | array $middleware): self
+    public function useMiddleware(string|array $middleware): self
     {
         $this->middleware = Arr::wrap($middleware);
 
@@ -58,16 +58,16 @@ class RouteRegistrar
         return $this->middleware ?? [];
     }
 
-    public function registerDirectory(string | array $directories): void
+    public function registerDirectory(string|array $directories): void
     {
         $directories = Arr::wrap($directories);
 
         $files = (new Finder())->files()->name('*.php')->in($directories);
 
-        collect($files)->each(fn (SplFileInfo $file) => $this->registerFile($file));
+        collect($files)->each(fn(SplFileInfo $file) => $this->registerFile($file));
     }
 
-    public function registerFile(string | SplFileInfo $path): void
+    public function registerFile(string|SplFileInfo $path): void
     {
         if (is_string($path)) {
             $path = new SplFileInfo($path);
@@ -98,7 +98,7 @@ class RouteRegistrar
 
     protected function processAttributes(string $className): void
     {
-        if (! class_exists($className)) {
+        if (!class_exists($className)) {
             return;
         }
 
@@ -111,7 +111,7 @@ class RouteRegistrar
         }
 
         ($prefix = $classRouteAttributes->prefix())
-            ? $this->router->prefix($prefix)->group(fn () => $this->registerRoutes($class, $classRouteAttributes))
+            ? $this->router->prefix($prefix)->group(fn() => $this->registerRoutes($class, $classRouteAttributes))
             : $this->registerRoutes($class, $classRouteAttributes);
     }
 
@@ -152,7 +152,7 @@ class RouteRegistrar
                     continue;
                 }
 
-                if (! $attributeClass instanceof Route) {
+                if (!$attributeClass instanceof Route) {
                     continue;
                 }
 
@@ -162,14 +162,13 @@ class RouteRegistrar
                     ? $class->getName()
                     : [$class->getName(), $method->getName()];
 
-                $router = $this->router;
+                $route = $this->router->addRoute($httpMethods, $attributeClass->uri, $action);
 
                 if ($domain = $classRouteAttributes->domainFromConfig() ?? $classRouteAttributes->domain()) {
-                    $router = $router->domain($domain);
+                    $route->domain($domain);
                 }
 
-                $route = $router->name($attributeClass->name)
-                    ->match($httpMethods, $attributeClass->uri, $action);
+                $route->name($attributeClass->name);
 
                 $wheres = $classRouteAttributes->wheres();
                 foreach ($wheresAttributes as $wheresAttribute) {
@@ -179,7 +178,7 @@ class RouteRegistrar
                     // This also overrides class wheres if the same param is used
                     $wheres[$wheresAttributeClass->param] = $wheresAttributeClass->constraint;
                 }
-                if (! empty($wheres)) {
+                if (!empty($wheres)) {
                     $route->setWheres($wheres);
                 }
 

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -162,15 +162,13 @@ class RouteRegistrar
                     ? $class->getName()
                     : [$class->getName(), $method->getName()];
 
-                $route = $this->router->addRoute($httpMethods, $attributeClass->uri, $action);
-
-                $route
-                    ->name($attributeClass->name);
-
-                if ($domain = $classRouteAttributes->domainFromConfig()) {
-                    $route->domain($domain);
-                } else if ($domain = $classRouteAttributes->domain()) {
-                    $route->domain($domain);
+                if ($domain = $classRouteAttributes->domainFromConfig() ?? $classRouteAttributes->domain()) {
+                    $route = $this->router->domain($domain)
+                        ->name($attributeClass->name)
+                        ->match($httpMethods, $attributeClass->uri, $action);
+                } else {
+                    $route = $this->router->addRoute($httpMethods, $attributeClass->uri, $action)
+                        ->name($attributeClass->name);
                 }
 
                 $wheres = $classRouteAttributes->wheres();

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -162,14 +162,14 @@ class RouteRegistrar
                     ? $class->getName()
                     : [$class->getName(), $method->getName()];
 
+                $router = $this->router;
+
                 if ($domain = $classRouteAttributes->domainFromConfig() ?? $classRouteAttributes->domain()) {
-                    $route = $this->router->domain($domain)
-                        ->name($attributeClass->name)
-                        ->match($httpMethods, $attributeClass->uri, $action);
-                } else {
-                    $route = $this->router->addRoute($httpMethods, $attributeClass->uri, $action)
-                        ->name($attributeClass->name);
+                    $router = $router->domain($domain);
                 }
+
+                $route = $router->name($attributeClass->name)
+                    ->match($httpMethods, $attributeClass->uri, $action);
 
                 $wheres = $classRouteAttributes->wheres();
                 foreach ($wheresAttributes as $wheresAttribute) {

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -162,13 +162,14 @@ class RouteRegistrar
                     ? $class->getName()
                     : [$class->getName(), $method->getName()];
 
-                $route = $this->router->addRoute($httpMethods, $attributeClass->uri, $action);
-
                 if ($domain = $classRouteAttributes->domainFromConfig() ?? $classRouteAttributes->domain()) {
-                    $route->domain($domain);
+                    $route = $this->router->domain($domain)
+                        ->name($attributeClass->name)
+                        ->match($httpMethods, $attributeClass->uri, $action);
+                } else {
+                    $route = $this->router->addRoute($httpMethods, $attributeClass->uri, $action)
+                        ->name($attributeClass->name);
                 }
-
-                $route->name($attributeClass->name);
 
                 $wheres = $classRouteAttributes->wheres();
                 foreach ($wheresAttributes as $wheresAttribute) {

--- a/tests/AttributeTests/Domain1AttributeTest.php
+++ b/tests/AttributeTests/Domain1AttributeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\RouteAttributes\Tests\AttributeTests;
+
+use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Domain1TestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Domain2TestController;
+
+class Domain1AttributeTest extends TestCase
+{
+    /** @test */
+    public function it_registers_the_same_url_on_different_domains()
+    {
+        config()->set('domains.test', 'config.localhost');
+        config()->set('domains.test2', 'config2.localhost');
+        $this->routeRegistrar->registerClass(Domain1TestController::class);
+        $this->routeRegistrar->registerClass(Domain2TestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(
+                Domain1TestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-get-method',
+                domain: 'config.localhost'
+            )
+            ->assertRouteRegistered(
+                Domain2TestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-get-method',
+                domain: 'config2.localhost'
+            );
+    }
+}

--- a/tests/AttributeTests/DomainFromConfigAttributeTest.php
+++ b/tests/AttributeTests/DomainFromConfigAttributeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\AttributeTests;
+
+use Illuminate\Support\Facades\Config;
+use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DomainFromConfigTestController;
+
+class DomainFromConfigAttributeTest extends TestCase
+{
+    /** @test */
+    public function it_can_apply_a_domain_on_the_url_of_every_method()
+    {
+        Config::set('domains.test', 'config.localhost');
+        $this->routeRegistrar->registerClass(DomainFromConfigTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(
+                DomainFromConfigTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-get-method',
+                domain: 'config.localhost'
+            )
+            ->assertRouteRegistered(
+                DomainFromConfigTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethods: 'post',
+                uri: 'my-post-method',
+                domain: 'config.localhost'
+            );
+    }
+}

--- a/tests/AttributeTests/DomainFromConfigAttributeTest.php
+++ b/tests/AttributeTests/DomainFromConfigAttributeTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
-use Illuminate\Support\Facades\Config;
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DomainFromConfigTestController;
 
@@ -11,7 +10,7 @@ class DomainFromConfigAttributeTest extends TestCase
     /** @test */
     public function it_can_apply_a_domain_on_the_url_of_every_method()
     {
-        Config::set('domains.test', 'config.localhost');
+        config()->set('domains.test', 'config.localhost');
         $this->routeRegistrar->registerClass(DomainFromConfigTestController::class);
 
         $this

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -73,11 +73,13 @@ class TestCase extends Orchestra
                     return false;
                 }
 
-                if (get_class($route->getController()) !== $controller) {
+                $routeController = $route->getAction(0) ?? get_class($route->getController());
+                if ($routeController !== $controller) {
                     return false;
                 }
 
-                if ($route->getActionMethod() !== $controllerMethod) {
+                $routeMethod = $route->getAction(1) ?? $route->getActionMethod();
+                if ($routeMethod !== $controllerMethod) {
                     return false;
                 }
 

--- a/tests/TestClasses/Controllers/Domain1TestController.php
+++ b/tests/TestClasses/Controllers/Domain1TestController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\DomainFromConfig;
+use Spatie\RouteAttributes\Attributes\Get;
+
+#[DomainFromConfig('domains.test')]
+class Domain1TestController
+{
+    #[Get('my-get-method')]
+    public function myGetMethod()
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/Domain2TestController.php
+++ b/tests/TestClasses/Controllers/Domain2TestController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\DomainFromConfig;
+use Spatie\RouteAttributes\Attributes\Get;
+
+#[DomainFromConfig('domains.test2')]
+class Domain2TestController
+{
+    #[Get('my-get-method')]
+    public function myGetMethod()
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/DomainFromConfigTestController.php
+++ b/tests/TestClasses/Controllers/DomainFromConfigTestController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\DomainFromConfig;
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Post;
+
+#[DomainFromConfig('domains.test')]
+class DomainFromConfigTestController
+{
+    #[Get('my-get-method')]
+    public function myGetMethod()
+    {
+    }
+
+    #[Post('my-post-method')]
+    public function myPostMethod()
+    {
+    }
+}


### PR DESCRIPTION
This PR adds in the functionality in order to be able to pull a domain from a specified configuration file. This is particularly useful when you have different subdomain urls between local and production. 

Further details are available in the updated readme. 