### PR TITLE
Additional Controller Namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ Route::post('my-post-route', [MyController::class, 'myPostMethod'])->domain('my-
 There maybe a need to define a domain from a configuration file, for example where
 your subdomain will be different on your development environment to your production environment.
 
-```
-config/domains.php
+```php
+// File: config/domains.php
 
 return [
     'main' => env('SITE_URL', 'example.com'),
@@ -365,6 +365,28 @@ For convenience, some commonly used regular expression patterns have helper attr
 #[WhereAlphaNumeric('alpha-numeric')]
 #[WhereNumber('number')]
 #[WhereUuid('uuid')]
+```
+
+### Alternative namespacing
+
+By default, the registration of routes uses the application's namespacing, but there may
+be instances where you have other PSR-4 namespaces defined in your application (this is 
+particularly possible if you have a monolith). 
+
+To let the router know about additional namespacing just add it in the
+[route-attributes.php](config/route-attributes.php) config file under the 
+`directory_namespaces` key. 
+
+For example, let's say you have a PSR-4 definition for some internal code in your package
+for MyOrg\MyPackage. All you need to provide is the directory as the key and the namespaced
+string as the value as illustrated below. 
+
+```php
+// File: route-attributes.php
+
+'directory_namespaces' => [
+   base_path('packages/myOrg/myPackage/src/Http/Controllers') => 'MyOrg\\MyPackage\\Http\\Controllers'
+],
 ```
 
 ## Testing

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Spatie\\RouteAttributes\\Tests\\": "tests"
+            "Spatie\\RouteAttributes\\Tests\\": "tests",
+            "MyOrg\\MyPackage\\": "tests/NamespacedClasses"
         }
     },
     "scripts": {

--- a/config/route-attributes.php
+++ b/config/route-attributes.php
@@ -15,6 +15,17 @@ return [
     ],
 
     /**
+     * You may have internal packages to your project which do not use the default
+     * namespacing, for example in a monolith, to define specific namespaces add
+     * to this array (location, namespace)
+     * e.g.
+     * base_path('packages/myOrg/myPackage/src/Http/Controllers') => 'MyOrg\\MyPackage\\Http\\Controllers'
+     */
+    'directory_namespaces' => [
+       // base_path('packages/myOrg/myPackage/src/Http/Controllers') => 'MyOrg\\MyPackage\\Http\\Controllers'
+    ],
+
+    /**
      * This middleware will be applied to all routes.
      */
     'middleware' => [

--- a/tests/NamespacedClasses/NamespacedTestController.php
+++ b/tests/NamespacedClasses/NamespacedTestController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MyOrg\MyPackage;
+
+use Spatie\RouteAttributes\Attributes\Get;
+
+class NamespacedTestController
+{
+    #[Get('my-namespaced-method')]
+    public function myNamespacedMethod()
+    {
+    }
+}

--- a/tests/NamespacedRouteRegistrarTest.php
+++ b/tests/NamespacedRouteRegistrarTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\RouteAttributes\Tests;
+
+use MyOrg\MyPackage\NamespacedTestController;
+
+class NamespacedRouteRegistrarTest extends TestCase
+{
+    /** @test */
+    public function the_registrar_can_register_a_single_file()
+    {
+        $this
+            ->routeRegistrar
+            ->registerFile($this->getTestPath('NamespacedClasses/NamespacedTestController.php'));
+
+        $this->assertRegisteredRoutesCount(1);
+
+        $this->assertRouteRegistered(
+            NamespacedTestController::class,
+            'myNamespacedMethod',
+            'GET',
+            'my-namespaced-method',
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,6 +18,10 @@ class TestCase extends Orchestra
     {
         parent::setUp();
 
+        config()->set('route-attributes.directory_namespaces', [
+            base_path('../../../../tests/NamespacedClasses') => 'MyOrg\\MyPackage',
+        ]);
+
         $router = app()->router;
 
         $this->routeRegistrar = (new RouteRegistrar($router))


### PR DESCRIPTION
By default, the registration of routes uses the application's namespacing, but there may be instances where you have other PSR-4 namespaces defined in your application (this is particularly possible if you have a monolith).

This PR creates a way to be able to define additional namespaces for specific directories where other controllers may reside. For more information, please see the update to the readme as part of this PR.