### PR TITLE
fix: use \ReflectionAttribute::IS_INSTANCEOF

### DIFF
--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -68,7 +68,7 @@ class ClassRouteAttributes
         $groups = [];
 
         /** @var ReflectionClass[] $attributes */
-        $attributes = $this->class->getAttributes(Group::class);
+        $attributes = $this->class->getAttributes(Group::class, \ReflectionAttribute::IS_INSTANCEOF);
         if (count($attributes) > 0) {
             foreach ($attributes as $attribute) {
                 $attributeClass = $attribute->newInstance();
@@ -161,7 +161,7 @@ class ClassRouteAttributes
     {
         $wheres = [];
         /** @var ReflectionClass[] $attributes */
-        $attributes = $this->class->getAttributes(Where::class);
+        $attributes = $this->class->getAttributes(Where::class, \ReflectionAttribute::IS_INSTANCEOF);
         foreach ($attributes as $attribute) {
             $attributeClass = $attribute->newInstance();
             $wheres[$attributeClass->param] = $attributeClass->constraint;
@@ -172,7 +172,7 @@ class ClassRouteAttributes
 
     protected function getAttribute(string $attributeClass): ?RouteAttribute
     {
-        $attributes = $this->class->getAttributes($attributeClass);
+        $attributes = $this->class->getAttributes($attributeClass, \ReflectionAttribute::IS_INSTANCEOF);
 
         if (! count($attributes)) {
             return null;


### PR DESCRIPTION
This PR will allow developers to inherit from the provided attributes and still keep the functionality, e.g.:
```php
<?php

namespace App\Attributes;

use Attribute;
use Spatie\RouteAttributes\Attributes\Group;

#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
class TeamGroup extends Group
{
    public function __construct(
        public ?string $prefix
    ) {
      parent::__construct('team/{team:slug}/' . $prefix);
    }
}