### PR TITLE
Add support for the names parameter to the Resource attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,15 @@ To register a [resource controller](https://laravel.com/docs/controllers#resourc
 
 You can use `only` or `except` parameters to manage your resource routes availability.
 
+You can use the `names` parameter to set the route names for the resource controller actions. Pass a string value to set a base route name for each controller action or pass an array value to define the route name for each controller action.
+
 Using `Resource` attribute with `Domain`, `Prefix` and `Middleware` attributes works as well.
 
 ```php
 use Spatie\RouteAttributes\Attributes\Resource;
 
 #[Prefix('api/v1')]
-#[Resource('posts', except: ['create', 'edit', 'destroy'])]
+#[Resource('posts', except: ['create', 'edit', 'destroy'], names: 'api.v1.posts')]
 class PostController
 {   
     public function index()

--- a/src/Attributes/Resource.php
+++ b/src/Attributes/Resource.php
@@ -12,6 +12,7 @@ class Resource implements RouteAttribute
         public bool $apiResource = false,
         public array | string | null $except = null,
         public array | string | null $only = null,
+        public array | string | null $names = null,
     ) {
     }
 }

--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -144,6 +144,19 @@ class ClassRouteAttributes
     /**
      * @psalm-suppress NoInterfaceProperties
      */
+    public function names(): string | array | null
+    {
+        /** @var \Spatie\RouteAttributes\Attributes\Resource $attribute */
+        if (! $attribute = $this->getAttribute(Resource::class)) {
+            return null;
+        }
+
+        return $attribute->names;
+    }
+
+    /**
+     * @psalm-suppress NoInterfaceProperties
+     */
     public function middleware(): array
     {
         /** @var \Spatie\RouteAttributes\Attributes\Middleware $attribute */

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -136,6 +136,10 @@ class RouteRegistrar
                 $route->except($except);
             }
 
+            if ($names = $classRouteAttributes->names()) {
+                $route->names($names);
+            }
+
             if ($middleware = $classRouteAttributes->middleware()) {
                 $route->middleware([...$this->middleware, ...$middleware]);
             }

--- a/tests/AttributeTests/ResourceAttributeTest.php
+++ b/tests/AttributeTests/ResourceAttributeTest.php
@@ -8,6 +8,8 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestDo
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestExceptController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestFullController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestMiddlewareController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestNamesArrayController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestNamesStringController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestOnlyController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestPrefixController;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
@@ -79,6 +81,48 @@ class ResourceAttributeTest extends TestCase
                 uri: 'posts/{post}',
                 name: 'posts.show',
                 domain: 'my-subdomain.localhost'
+            );
+    }
+
+    /** @test */
+    public function it_can_register_resource_with_names_as_string()
+    {
+        $this->routeRegistrar->registerClass(ResourceTestNamesStringController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(
+                ResourceTestNamesStringController::class,
+                controllerMethod: 'index',
+                uri: 'posts',
+                name: 'api.v1.posts.index',
+            )
+            ->assertRouteRegistered(
+                ResourceTestNamesStringController::class,
+                controllerMethod: 'show',
+                uri: 'posts/{post}',
+                name: 'api.v1.posts.show',
+            );
+    }
+
+    /** @test */
+    public function it_can_register_resource_with_names_as_array()
+    {
+        $this->routeRegistrar->registerClass(ResourceTestNamesArrayController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(
+                ResourceTestNamesArrayController::class,
+                controllerMethod: 'index',
+                uri: 'posts',
+                name: 'posts.list',
+            )
+            ->assertRouteRegistered(
+                ResourceTestNamesArrayController::class,
+                controllerMethod: 'show',
+                uri: 'posts/{post}',
+                name: 'posts.view',
             );
     }
 

--- a/tests/TestClasses/Controllers/Resource/ResourceTestNamesArrayController.php
+++ b/tests/TestClasses/Controllers/Resource/ResourceTestNamesArrayController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource;
+
+use Spatie\RouteAttributes\Attributes\Resource;
+
+#[Resource('posts', only: ['index', 'show'], names: ['index' => 'posts.list', 'show' => 'posts.view'])]
+class ResourceTestNamesArrayController
+{
+    public function index()
+    {
+    }
+
+    public function show($id)
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/Resource/ResourceTestNamesStringController.php
+++ b/tests/TestClasses/Controllers/Resource/ResourceTestNamesStringController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource;
+
+use Spatie\RouteAttributes\Attributes\Resource;
+
+#[Resource('posts', only: ['index', 'show'], names: 'api.v1.posts')]
+class ResourceTestNamesStringController
+{
+    public function index()
+    {
+    }
+
+    public function show($id)
+    {
+    }
+}


### PR DESCRIPTION
This allows you to specify the `names` parameter on the `Resource`.

If you had something like:
```php
#[Resource('posts', only: ['index', 'show'], names: 'api.v1.posts')]
class ResourceTestNamesStringController
{
    public function index()
    {
    }

    public function show($id)
    {
    }
}
```

You would get routes named:
`api.v1.posts.index`
`api.v1.posts.show`

You can also pass an array to the `names` parameter if you want to customize the route name for each controller action:

```php
#[Resource('posts', only: ['index', 'show'], names: ['index' => 'posts.list', 'show' => 'posts.view'])]
```

You would get routes named:
`posts.list`
`posts.view`
