### PR TITLE
Allow routes to be bound from namespaces other than `App\`.  #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ return [
      */
     'enabled' => true,
 
-    /*
+   /*
      * Controllers in these directories that have routing attributes
      * will automatically be registered.
+     * Also you can use 'namespace => directory' pair
      */
     'directories' => [
         app_path('Http/Controllers'),
@@ -70,6 +71,27 @@ return [
 ];
 ```
 
+Also, you can also specify a namespace by using the "key-value" pair as directories.For instance, if you're using a different module, like `nWidart/laravel-modules`, you can specify namespaces this way.
+
+```php
+return [
+    /*
+     *  Automatic registration of routes will only happen if this setting is `true`
+     */
+    'enabled' => true,
+
+   /*
+     * Controllers in these directories that have routing attributes
+     * will automatically be registered.
+     * Also you can use 'namespace => directory' pair
+     */
+    'directories' => [
+        app_path('Http/Controllers'),
+        'Modules\Admin\Http\Controllers' => base_path('Modules/Admin/Http/Controllers'),
+        'Acme\Foo\Bar\Http\Controllers' => base_path('Modules/Foo/Bar/Http/Controllers'),
+    ],
+];
+```
 ## Usage
 
 The package provides several annotations that should be put on controller classes and methods. These annotations will be used to automatically register routes

--- a/config/route-attributes.php
+++ b/config/route-attributes.php
@@ -9,6 +9,7 @@ return [
     /*
      * Controllers in these directories that have routing attributes
      * will automatically be registered.
+     * Also you can use 'namespace => directory' pair
      */
     'directories' => [
         app_path('Http/Controllers'),

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -32,9 +32,7 @@ class RouteAttributesServiceProvider extends ServiceProvider
             ->useMiddleware(config('route-attributes.middleware') ?? []);
 
 
-        collect($this->getRouteDirectories())->each(function (string $directory, string|int $namespace) use (
-            $routeRegistrar
-        ) {
+        collect($this->getRouteDirectories())->each(function (string $directory, string|int $namespace) use ($routeRegistrar) {
             if (!is_string($namespace)) {
                 $routeRegistrar
                     ->hasNamespaceKey(false)

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -100,6 +100,7 @@ class RouteRegistrar
 
         if ($this->hasNamespaceKey) {
             $class = '\\'.ucfirst(Str::replaceLast('.php', '', $class));
+            $class = str_replace('/', '\\', $class);
         } else {
             $class = str_replace(
                 [DIRECTORY_SEPARATOR, 'App\\'],


### PR DESCRIPTION
This allows routes to be bounded from namespaces other than App.
Most importantly, indexed arrays are allowed as used in the past to avoid backward-compability problems.
```
return [
    /*
     *  Automatic registration of routes will only happen if this setting is `true`
     */
    'enabled' => true,

    /*
     * Controllers in these directories that have routing attributes
     * will automatically be registered.
     */
    'directories' => [
        'App\Http\Controllers' => app_path('Http/Controllers'),
        'User\Package\Http\Controllers => 'base_path('vendor/user/package/src/Http/Controllers'),
        'Modules\Admin\Http\Controllers' => base_path('Modules/Admin/Http/Controllers'),
        'Acme\Foo\Bar\Http\Controllers' => base_path('Modules/Foo/Bar/Http/Controllers'),
    ],

    /**
     * This middleware will be applied to all routes.
     */
    'middleware' => [
        \Illuminate\Routing\Middleware\SubstituteBindings::class
    ]
];
```