### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,4 +41,4 @@ jobs:
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.3",
         "psalm/plugin-laravel": "^1.4",
-        "vimeo/psalm": "^4.1"
+        "vimeo/psalm": "^4.1",
+        "pestphp/pest": "^1.20"
     },
     "autoload": {
         "psr-4": {

--- a/tests/AttributeTests/AnyAttributeTest.php
+++ b/tests/AttributeTests/AnyAttributeTest.php
@@ -1,25 +1,20 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\AnyTestController;
 
-class AnyAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_register_an_any_route()
-    {
-        $this->routeRegistrar->registerClass(AnyTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'head', 'my-any-method')
-            ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'get', 'my-any-method')
-            ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'post', 'my-any-method')
-            ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'put', 'my-any-method')
-            ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'patch', 'my-any-method')
-            ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'delete', 'my-any-method')
-            ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'options', 'my-any-method');
-    }
-}
+it('can register an any route', function () {
+    $this->routeRegistrar->registerClass(AnyTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'head', 'my-any-method')
+        ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'get', 'my-any-method')
+        ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'post', 'my-any-method')
+        ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'put', 'my-any-method')
+        ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'patch', 'my-any-method')
+        ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'delete', 'my-any-method')
+        ->assertRouteRegistered(AnyTestController::class, 'myAnyMethod', 'options', 'my-any-method');
+});

--- a/tests/AttributeTests/AnyAttributeTest.php
+++ b/tests/AttributeTests/AnyAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\AnyTestController;
 
-uses(TestCase::class);
 
 it('can register an any route', function () {
     $this->routeRegistrar->registerClass(AnyTestController::class);

--- a/tests/AttributeTests/AnyAttributeTest.php
+++ b/tests/AttributeTests/AnyAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\AnyTestController;
-
 
 it('can register an any route', function () {
     $this->routeRegistrar->registerClass(AnyTestController::class);

--- a/tests/AttributeTests/DeleteAttributeTest.php
+++ b/tests/AttributeTests/DeleteAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DeleteTestController;
 
-uses(TestCase::class);
 
 it('can register a delete route', function () {
     $this->routeRegistrar->registerClass(DeleteTestController::class);

--- a/tests/AttributeTests/DeleteAttributeTest.php
+++ b/tests/AttributeTests/DeleteAttributeTest.php
@@ -1,19 +1,14 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DeleteTestController;
 
-class DeleteAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_register_a_delete_route()
-    {
-        $this->routeRegistrar->registerClass(DeleteTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(DeleteTestController::class, 'myDeleteMethod', 'delete', 'my-delete-method');
-    }
-}
+it('can register a delete route', function () {
+    $this->routeRegistrar->registerClass(DeleteTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(DeleteTestController::class, 'myDeleteMethod', 'delete', 'my-delete-method');
+});

--- a/tests/AttributeTests/DeleteAttributeTest.php
+++ b/tests/AttributeTests/DeleteAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DeleteTestController;
-
 
 it('can register a delete route', function () {
     $this->routeRegistrar->registerClass(DeleteTestController::class);

--- a/tests/AttributeTests/Domain1AttributeTest.php
+++ b/tests/AttributeTests/Domain1AttributeTest.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Domain1TestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Domain2TestController;
-
 
 it('registers the same url on different domains', function () {
     config()->set('domains.test', 'config.localhost');

--- a/tests/AttributeTests/Domain1AttributeTest.php
+++ b/tests/AttributeTests/Domain1AttributeTest.php
@@ -6,7 +6,6 @@ use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Domain1TestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Domain2TestController;
 
-uses(TestCase::class);
 
 it('registers the same url on different domains', function () {
     config()->set('domains.test', 'config.localhost');

--- a/tests/AttributeTests/Domain1AttributeTest.php
+++ b/tests/AttributeTests/Domain1AttributeTest.php
@@ -2,35 +2,30 @@
 
 declare(strict_types=1);
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Domain1TestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Domain2TestController;
 
-class Domain1AttributeTest extends TestCase
-{
-    /** @test */
-    public function it_registers_the_same_url_on_different_domains()
-    {
-        config()->set('domains.test', 'config.localhost');
-        config()->set('domains.test2', 'config2.localhost');
-        $this->routeRegistrar->registerClass(Domain1TestController::class);
-        $this->routeRegistrar->registerClass(Domain2TestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(2)
-            ->assertRouteRegistered(
-                Domain1TestController::class,
-                controllerMethod: 'myGetMethod',
-                uri: 'my-get-method',
-                domain: 'config.localhost'
-            )
-            ->assertRouteRegistered(
-                Domain2TestController::class,
-                controllerMethod: 'myGetMethod',
-                uri: 'my-get-method',
-                domain: 'config2.localhost'
-            );
-    }
-}
+it('registers the same url on different domains', function () {
+    config()->set('domains.test', 'config.localhost');
+    config()->set('domains.test2', 'config2.localhost');
+    $this->routeRegistrar->registerClass(Domain1TestController::class);
+    $this->routeRegistrar->registerClass(Domain2TestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            Domain1TestController::class,
+            controllerMethod: 'myGetMethod',
+            uri: 'my-get-method',
+            domain: 'config.localhost'
+        )
+        ->assertRouteRegistered(
+            Domain2TestController::class,
+            controllerMethod: 'myGetMethod',
+            uri: 'my-get-method',
+            domain: 'config2.localhost'
+        );
+});

--- a/tests/AttributeTests/DomainAttributeTest.php
+++ b/tests/AttributeTests/DomainAttributeTest.php
@@ -1,31 +1,26 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DomainTestController;
 
-class DomainAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_apply_a_domain_on_the_url_of_every_method()
-    {
-        $this->routeRegistrar->registerClass(DomainTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(2)
-            ->assertRouteRegistered(
-                DomainTestController::class,
-                controllerMethod: 'myGetMethod',
-                uri: 'my-get-method',
-                domain: 'my-subdomain.localhost'
-            )
-            ->assertRouteRegistered(
-                DomainTestController::class,
-                controllerMethod: 'myPostMethod',
-                httpMethods: 'post',
-                uri: 'my-post-method',
-                domain: 'my-subdomain.localhost'
-            );
-    }
-}
+it('can apply a domain on the url of every method', function () {
+    $this->routeRegistrar->registerClass(DomainTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            DomainTestController::class,
+            controllerMethod: 'myGetMethod',
+            uri: 'my-get-method',
+            domain: 'my-subdomain.localhost'
+        )
+        ->assertRouteRegistered(
+            DomainTestController::class,
+            controllerMethod: 'myPostMethod',
+            httpMethods: 'post',
+            uri: 'my-post-method',
+            domain: 'my-subdomain.localhost'
+        );
+});

--- a/tests/AttributeTests/DomainAttributeTest.php
+++ b/tests/AttributeTests/DomainAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DomainTestController;
 
-uses(TestCase::class);
 
 it('can apply a domain on the url of every method', function () {
     $this->routeRegistrar->registerClass(DomainTestController::class);

--- a/tests/AttributeTests/DomainAttributeTest.php
+++ b/tests/AttributeTests/DomainAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DomainTestController;
-
 
 it('can apply a domain on the url of every method', function () {
     $this->routeRegistrar->registerClass(DomainTestController::class);

--- a/tests/AttributeTests/DomainFromConfigAttributeTest.php
+++ b/tests/AttributeTests/DomainFromConfigAttributeTest.php
@@ -1,32 +1,27 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DomainFromConfigTestController;
 
-class DomainFromConfigAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_apply_a_domain_on_the_url_of_every_method()
-    {
-        config()->set('domains.test', 'config.localhost');
-        $this->routeRegistrar->registerClass(DomainFromConfigTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(2)
-            ->assertRouteRegistered(
-                DomainFromConfigTestController::class,
-                controllerMethod: 'myGetMethod',
-                uri: 'my-get-method',
-                domain: 'config.localhost'
-            )
-            ->assertRouteRegistered(
-                DomainFromConfigTestController::class,
-                controllerMethod: 'myPostMethod',
-                httpMethods: 'post',
-                uri: 'my-post-method',
-                domain: 'config.localhost'
-            );
-    }
-}
+it('can apply a domain on the url of every method', function () {
+    config()->set('domains.test', 'config.localhost');
+    $this->routeRegistrar->registerClass(DomainFromConfigTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            DomainFromConfigTestController::class,
+            controllerMethod: 'myGetMethod',
+            uri: 'my-get-method',
+            domain: 'config.localhost'
+        )
+        ->assertRouteRegistered(
+            DomainFromConfigTestController::class,
+            controllerMethod: 'myPostMethod',
+            httpMethods: 'post',
+            uri: 'my-post-method',
+            domain: 'config.localhost'
+        );
+});

--- a/tests/AttributeTests/DomainFromConfigAttributeTest.php
+++ b/tests/AttributeTests/DomainFromConfigAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DomainFromConfigTestController;
 
-uses(TestCase::class);
 
 it('can apply a domain on the url of every method', function () {
     config()->set('domains.test', 'config.localhost');

--- a/tests/AttributeTests/DomainFromConfigAttributeTest.php
+++ b/tests/AttributeTests/DomainFromConfigAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DomainFromConfigTestController;
-
 
 it('can apply a domain on the url of every method', function () {
     config()->set('domains.test', 'config.localhost');

--- a/tests/AttributeTests/GetAttributeTest.php
+++ b/tests/AttributeTests/GetAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\GetTestController;
-
 
 it('can register a get route', function () {
     $this->routeRegistrar->registerClass(GetTestController::class);

--- a/tests/AttributeTests/GetAttributeTest.php
+++ b/tests/AttributeTests/GetAttributeTest.php
@@ -1,19 +1,14 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\GetTestController;
 
-class GetAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_register_a_get_route()
-    {
-        $this->routeRegistrar->registerClass(GetTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(GetTestController::class, 'myGetMethod', 'get', 'my-get-method');
-    }
-}
+it('can register a get route', function () {
+    $this->routeRegistrar->registerClass(GetTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(GetTestController::class, 'myGetMethod', 'get', 'my-get-method');
+});

--- a/tests/AttributeTests/GetAttributeTest.php
+++ b/tests/AttributeTests/GetAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\GetTestController;
 
-uses(TestCase::class);
 
 it('can register a get route', function () {
     $this->routeRegistrar->registerClass(GetTestController::class);

--- a/tests/AttributeTests/GroupAttributeTest.php
+++ b/tests/AttributeTests/GroupAttributeTest.php
@@ -1,44 +1,39 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\GroupTestController;
 
-class GroupAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_apply_a_domain_on_the_url_of_every_method()
-    {
-        $this->routeRegistrar->registerClass(GroupTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(4)
-            ->assertRouteRegistered(
-                GroupTestController::class,
-                controllerMethod: 'myGetMethod',
-                uri: 'my-prefix/my-get-method',
-                domain: 'my-subdomain.localhost'
-            )
-            ->assertRouteRegistered(
-                GroupTestController::class,
-                controllerMethod: 'myPostMethod',
-                httpMethods: 'post',
-                uri: 'my-prefix/my-post-method',
-                domain: 'my-subdomain.localhost'
-            )
-            ->assertRouteRegistered(
-                GroupTestController::class,
-                controllerMethod: 'myGetMethod',
-                uri: 'my-second-prefix/my-get-method',
-                domain: 'my-second-subdomain.localhost'
-            )
-            ->assertRouteRegistered(
-                GroupTestController::class,
-                controllerMethod: 'myPostMethod',
-                httpMethods: 'post',
-                uri: 'my-second-prefix/my-post-method',
-                domain: 'my-second-subdomain.localhost'
-            );
-    }
-}
+it('can apply a domain on the url of every method', function () {
+    $this->routeRegistrar->registerClass(GroupTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(4)
+        ->assertRouteRegistered(
+            GroupTestController::class,
+            controllerMethod: 'myGetMethod',
+            uri: 'my-prefix/my-get-method',
+            domain: 'my-subdomain.localhost'
+        )
+        ->assertRouteRegistered(
+            GroupTestController::class,
+            controllerMethod: 'myPostMethod',
+            httpMethods: 'post',
+            uri: 'my-prefix/my-post-method',
+            domain: 'my-subdomain.localhost'
+        )
+        ->assertRouteRegistered(
+            GroupTestController::class,
+            controllerMethod: 'myGetMethod',
+            uri: 'my-second-prefix/my-get-method',
+            domain: 'my-second-subdomain.localhost'
+        )
+        ->assertRouteRegistered(
+            GroupTestController::class,
+            controllerMethod: 'myPostMethod',
+            httpMethods: 'post',
+            uri: 'my-second-prefix/my-post-method',
+            domain: 'my-second-subdomain.localhost'
+        );
+});

--- a/tests/AttributeTests/GroupAttributeTest.php
+++ b/tests/AttributeTests/GroupAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\GroupTestController;
-
 
 it('can apply a domain on the url of every method', function () {
     $this->routeRegistrar->registerClass(GroupTestController::class);

--- a/tests/AttributeTests/GroupAttributeTest.php
+++ b/tests/AttributeTests/GroupAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\GroupTestController;
 
-uses(TestCase::class);
 
 it('can apply a domain on the url of every method', function () {
     $this->routeRegistrar->registerClass(GroupTestController::class);

--- a/tests/AttributeTests/MiddlewareAttributeTest.php
+++ b/tests/AttributeTests/MiddlewareAttributeTest.php
@@ -1,32 +1,27 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\MiddlewareTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
-class MiddlewareAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_apply_middleware_on_each_method_of_a_controller()
-    {
-        $this->routeRegistrar->registerClass(MiddlewareTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(2)
-            ->assertRouteRegistered(
-                MiddlewareTestController::class,
-                controllerMethod: 'singleMiddleware',
-                uri: 'single-middleware',
-                middleware: [TestMiddleware::class],
-            )
-            ->assertRouteRegistered(
-                MiddlewareTestController::class,
-                controllerMethod: 'multipleMiddleware',
-                uri: 'multiple-middleware',
-                middleware: [TestMiddleware::class, OtherTestMiddleware::class],
-            );
-    }
-}
+it('can apply middleware on each method of a controller', function () {
+    $this->routeRegistrar->registerClass(MiddlewareTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            MiddlewareTestController::class,
+            controllerMethod: 'singleMiddleware',
+            uri: 'single-middleware',
+            middleware: [TestMiddleware::class],
+        )
+        ->assertRouteRegistered(
+            MiddlewareTestController::class,
+            controllerMethod: 'multipleMiddleware',
+            uri: 'multiple-middleware',
+            middleware: [TestMiddleware::class, OtherTestMiddleware::class],
+        );
+});

--- a/tests/AttributeTests/MiddlewareAttributeTest.php
+++ b/tests/AttributeTests/MiddlewareAttributeTest.php
@@ -5,7 +5,6 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\MiddlewareTestControlle
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
-uses(TestCase::class);
 
 it('can apply middleware on each method of a controller', function () {
     $this->routeRegistrar->registerClass(MiddlewareTestController::class);

--- a/tests/AttributeTests/MiddlewareAttributeTest.php
+++ b/tests/AttributeTests/MiddlewareAttributeTest.php
@@ -1,10 +1,8 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\MiddlewareTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
-
 
 it('can apply middleware on each method of a controller', function () {
     $this->routeRegistrar->registerClass(MiddlewareTestController::class);

--- a/tests/AttributeTests/OptionsAttributeTest.php
+++ b/tests/AttributeTests/OptionsAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\OptionsTestController;
-
 
 it('can register a options route', function () {
     $this->routeRegistrar->registerClass(OptionsTestController::class);

--- a/tests/AttributeTests/OptionsAttributeTest.php
+++ b/tests/AttributeTests/OptionsAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\OptionsTestController;
 
-uses(TestCase::class);
 
 it('can register a options route', function () {
     $this->routeRegistrar->registerClass(OptionsTestController::class);

--- a/tests/AttributeTests/OptionsAttributeTest.php
+++ b/tests/AttributeTests/OptionsAttributeTest.php
@@ -1,19 +1,14 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\OptionsTestController;
 
-class OptionsAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_register_a_options_route()
-    {
-        $this->routeRegistrar->registerClass(OptionsTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(OptionsTestController::class, 'myOptionsMethod', 'options', 'my-options-method');
-    }
-}
+it('can register a options route', function () {
+    $this->routeRegistrar->registerClass(OptionsTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(OptionsTestController::class, 'myOptionsMethod', 'options', 'my-options-method');
+});

--- a/tests/AttributeTests/PatchAttributeTest.php
+++ b/tests/AttributeTests/PatchAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PatchTestController;
-
 
 it('can register a patch route', function () {
     $this->routeRegistrar->registerClass(PatchTestController::class);

--- a/tests/AttributeTests/PatchAttributeTest.php
+++ b/tests/AttributeTests/PatchAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PatchTestController;
 
-uses(TestCase::class);
 
 it('can register a patch route', function () {
     $this->routeRegistrar->registerClass(PatchTestController::class);

--- a/tests/AttributeTests/PatchAttributeTest.php
+++ b/tests/AttributeTests/PatchAttributeTest.php
@@ -1,19 +1,14 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PatchTestController;
 
-class PatchAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_register_a_patch_route()
-    {
-        $this->routeRegistrar->registerClass(PatchTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(PatchTestController::class, 'myPatchMethod', 'patch', 'my-patch-method');
-    }
-}
+it('can register a patch route', function () {
+    $this->routeRegistrar->registerClass(PatchTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(PatchTestController::class, 'myPatchMethod', 'patch', 'my-patch-method');
+});

--- a/tests/AttributeTests/PostAttributeTest.php
+++ b/tests/AttributeTests/PostAttributeTest.php
@@ -1,19 +1,14 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PostTestController;
 
-class PostAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_register_a_post_route()
-    {
-        $this->routeRegistrar->registerClass(PostTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(PostTestController::class, 'myPostMethod', 'post', 'my-post-method');
-    }
-}
+it('can register a post route', function () {
+    $this->routeRegistrar->registerClass(PostTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(PostTestController::class, 'myPostMethod', 'post', 'my-post-method');
+});

--- a/tests/AttributeTests/PostAttributeTest.php
+++ b/tests/AttributeTests/PostAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PostTestController;
 
-uses(TestCase::class);
 
 it('can register a post route', function () {
     $this->routeRegistrar->registerClass(PostTestController::class);

--- a/tests/AttributeTests/PostAttributeTest.php
+++ b/tests/AttributeTests/PostAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PostTestController;
-
 
 it('can register a post route', function () {
     $this->routeRegistrar->registerClass(PostTestController::class);

--- a/tests/AttributeTests/PrefixAttributeTest.php
+++ b/tests/AttributeTests/PrefixAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PrefixTestController;
 
-uses(TestCase::class);
 
 it('can apply a prefix on the url of every method', function () {
     $this->routeRegistrar->registerClass(PrefixTestController::class);

--- a/tests/AttributeTests/PrefixAttributeTest.php
+++ b/tests/AttributeTests/PrefixAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PrefixTestController;
-
 
 it('can apply a prefix on the url of every method', function () {
     $this->routeRegistrar->registerClass(PrefixTestController::class);

--- a/tests/AttributeTests/PrefixAttributeTest.php
+++ b/tests/AttributeTests/PrefixAttributeTest.php
@@ -1,34 +1,29 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PrefixTestController;
 
-class PrefixAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_apply_a_prefix_on_the_url_of_every_method()
-    {
-        $this->routeRegistrar->registerClass(PrefixTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(3)
-            ->assertRouteRegistered(
-                PrefixTestController::class,
-                controllerMethod: 'myRootGetMethod',
-                uri: 'my-prefix',
-            )
-            ->assertRouteRegistered(
-                PrefixTestController::class,
-                controllerMethod: 'myGetMethod',
-                uri: 'my-prefix/my-get-method',
-            )
-            ->assertRouteRegistered(
-                PrefixTestController::class,
-                controllerMethod: 'myPostMethod',
-                httpMethods: 'post',
-                uri: 'my-prefix/my-post-method',
-            );
-    }
-}
+it('can apply a prefix on the url of every method', function () {
+    $this->routeRegistrar->registerClass(PrefixTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(3)
+        ->assertRouteRegistered(
+            PrefixTestController::class,
+            controllerMethod: 'myRootGetMethod',
+            uri: 'my-prefix',
+        )
+        ->assertRouteRegistered(
+            PrefixTestController::class,
+            controllerMethod: 'myGetMethod',
+            uri: 'my-prefix/my-get-method',
+        )
+        ->assertRouteRegistered(
+            PrefixTestController::class,
+            controllerMethod: 'myPostMethod',
+            httpMethods: 'post',
+            uri: 'my-prefix/my-post-method',
+        );
+});

--- a/tests/AttributeTests/PutAttributeTest.php
+++ b/tests/AttributeTests/PutAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PutTestController;
 
-uses(TestCase::class);
 
 it('can register a put route', function () {
     $this->routeRegistrar->registerClass(PutTestController::class);

--- a/tests/AttributeTests/PutAttributeTest.php
+++ b/tests/AttributeTests/PutAttributeTest.php
@@ -1,19 +1,14 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PutTestController;
 
-class PutAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_register_a_put_route()
-    {
-        $this->routeRegistrar->registerClass(PutTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(PutTestController::class, 'myPutMethod', 'put', 'my-put-method');
-    }
-}
+it('can register a put route', function () {
+    $this->routeRegistrar->registerClass(PutTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(PutTestController::class, 'myPutMethod', 'put', 'my-put-method');
+});

--- a/tests/AttributeTests/PutAttributeTest.php
+++ b/tests/AttributeTests/PutAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PutTestController;
-
 
 it('can register a put route', function () {
     $this->routeRegistrar->registerClass(PutTestController::class);

--- a/tests/AttributeTests/ResourceAttributeTest.php
+++ b/tests/AttributeTests/ResourceAttributeTest.php
@@ -13,7 +13,6 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestPr
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
-uses(TestCase::class);
 
 it('can register resource with prefix', function () {
     $this->routeRegistrar->registerClass(ResourceTestPrefixController::class);

--- a/tests/AttributeTests/ResourceAttributeTest.php
+++ b/tests/AttributeTests/ResourceAttributeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestApiController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestDomainController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestExceptController;
@@ -12,7 +11,6 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestOn
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestPrefixController;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
-
 
 it('can register resource with prefix', function () {
     $this->routeRegistrar->registerClass(ResourceTestPrefixController::class);

--- a/tests/AttributeTests/ResourceAttributeTest.php
+++ b/tests/AttributeTests/ResourceAttributeTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestApiController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestDomainController;
@@ -15,278 +13,259 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestPr
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
-class ResourceAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_register_resource_with_prefix()
-    {
-        $this->routeRegistrar->registerClass(ResourceTestPrefixController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(2)
-            ->assertRouteRegistered(
-                ResourceTestPrefixController::class,
-                controllerMethod: 'index',
-                uri: 'api/v1/my-prefix/etc/posts',
-                name: 'posts.index'
-            )
-            ->assertRouteRegistered(
-                ResourceTestPrefixController::class,
-                controllerMethod: 'show',
-                uri: 'api/v1/my-prefix/etc/posts/{post}',
-                name: 'posts.show'
-            );
-    }
+it('can register resource with prefix', function () {
+    $this->routeRegistrar->registerClass(ResourceTestPrefixController::class);
 
-    /** @test */
-    public function it_can_register_resource_with_middleware()
-    {
-        $this->routeRegistrar->registerClass(ResourceTestMiddlewareController::class);
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            ResourceTestPrefixController::class,
+            controllerMethod: 'index',
+            uri: 'api/v1/my-prefix/etc/posts',
+            name: 'posts.index'
+        )
+        ->assertRouteRegistered(
+            ResourceTestPrefixController::class,
+            controllerMethod: 'show',
+            uri: 'api/v1/my-prefix/etc/posts/{post}',
+            name: 'posts.show'
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(2)
-            ->assertRouteRegistered(
-                ResourceTestMiddlewareController::class,
-                controllerMethod: 'index',
-                uri: 'posts',
-                middleware: [TestMiddleware::class, OtherTestMiddleware::class],
-                name: 'posts.index',
-            )
-            ->assertRouteRegistered(
-                ResourceTestMiddlewareController::class,
-                controllerMethod: 'show',
-                uri: 'posts/{post}',
-                middleware: [TestMiddleware::class, OtherTestMiddleware::class],
-                name: 'posts.show',
-            );
-    }
+it('can register resource with middleware', function () {
+    $this->routeRegistrar->registerClass(ResourceTestMiddlewareController::class);
 
-    /** @test */
-    public function it_can_register_resource_with_domain()
-    {
-        $this->routeRegistrar->registerClass(ResourceTestDomainController::class);
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            ResourceTestMiddlewareController::class,
+            controllerMethod: 'index',
+            uri: 'posts',
+            middleware: [TestMiddleware::class, OtherTestMiddleware::class],
+            name: 'posts.index',
+        )
+        ->assertRouteRegistered(
+            ResourceTestMiddlewareController::class,
+            controllerMethod: 'show',
+            uri: 'posts/{post}',
+            middleware: [TestMiddleware::class, OtherTestMiddleware::class],
+            name: 'posts.show',
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(2)
-            ->assertRouteRegistered(
-                ResourceTestDomainController::class,
-                controllerMethod: 'index',
-                uri: 'posts',
-                name: 'posts.index',
-                domain: 'my-subdomain.localhost'
-            )
-            ->assertRouteRegistered(
-                ResourceTestDomainController::class,
-                controllerMethod: 'show',
-                uri: 'posts/{post}',
-                name: 'posts.show',
-                domain: 'my-subdomain.localhost'
-            );
-    }
+it('can register resource with domain', function () {
+    $this->routeRegistrar->registerClass(ResourceTestDomainController::class);
 
-    /** @test */
-    public function it_can_register_resource_with_names_as_string()
-    {
-        $this->routeRegistrar->registerClass(ResourceTestNamesStringController::class);
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            ResourceTestDomainController::class,
+            controllerMethod: 'index',
+            uri: 'posts',
+            name: 'posts.index',
+            domain: 'my-subdomain.localhost'
+        )
+        ->assertRouteRegistered(
+            ResourceTestDomainController::class,
+            controllerMethod: 'show',
+            uri: 'posts/{post}',
+            name: 'posts.show',
+            domain: 'my-subdomain.localhost'
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(2)
-            ->assertRouteRegistered(
-                ResourceTestNamesStringController::class,
-                controllerMethod: 'index',
-                uri: 'posts',
-                name: 'api.v1.posts.index',
-            )
-            ->assertRouteRegistered(
-                ResourceTestNamesStringController::class,
-                controllerMethod: 'show',
-                uri: 'posts/{post}',
-                name: 'api.v1.posts.show',
-            );
-    }
+it('can register resource with names as string', function () {
+    $this->routeRegistrar->registerClass(ResourceTestNamesStringController::class);
 
-    /** @test */
-    public function it_can_register_resource_with_names_as_array()
-    {
-        $this->routeRegistrar->registerClass(ResourceTestNamesArrayController::class);
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            ResourceTestNamesStringController::class,
+            controllerMethod: 'index',
+            uri: 'posts',
+            name: 'api.v1.posts.index',
+        )
+        ->assertRouteRegistered(
+            ResourceTestNamesStringController::class,
+            controllerMethod: 'show',
+            uri: 'posts/{post}',
+            name: 'api.v1.posts.show',
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(2)
-            ->assertRouteRegistered(
-                ResourceTestNamesArrayController::class,
-                controllerMethod: 'index',
-                uri: 'posts',
-                name: 'posts.list',
-            )
-            ->assertRouteRegistered(
-                ResourceTestNamesArrayController::class,
-                controllerMethod: 'show',
-                uri: 'posts/{post}',
-                name: 'posts.view',
-            );
-    }
+it('can register resource with names as array', function () {
+    $this->routeRegistrar->registerClass(ResourceTestNamesArrayController::class);
 
-    /** @test */
-    public function it_can_register_resource_with_all_methods()
-    {
-        $this->routeRegistrar->registerClass(ResourceTestFullController::class);
+    $this
+        ->assertRegisteredRoutesCount(2)
+        ->assertRouteRegistered(
+            ResourceTestNamesArrayController::class,
+            controllerMethod: 'index',
+            uri: 'posts',
+            name: 'posts.list',
+        )
+        ->assertRouteRegistered(
+            ResourceTestNamesArrayController::class,
+            controllerMethod: 'show',
+            uri: 'posts/{post}',
+            name: 'posts.view',
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(7)
-            ->assertRouteRegistered(
-                ResourceTestFullController::class,
-                controllerMethod: 'index',
-                uri: 'posts',
-                name: 'posts.index'
-            )
-            ->assertRouteRegistered(
-                ResourceTestFullController::class,
-                controllerMethod: 'create',
-                uri: 'posts/create',
-                name: 'posts.create'
-            )
-            ->assertRouteRegistered(
-                ResourceTestFullController::class,
-                controllerMethod: 'store',
-                httpMethods: 'post',
-                uri: 'posts',
-                name: 'posts.store'
-            )
-            ->assertRouteRegistered(
-                ResourceTestFullController::class,
-                controllerMethod: 'show',
-                uri: 'posts/{post}',
-                name: 'posts.show'
-            )
-            ->assertRouteRegistered(
-                ResourceTestFullController::class,
-                controllerMethod: 'edit',
-                uri: 'posts/{post}/edit',
-                name: 'posts.edit'
-            )
-            ->assertRouteRegistered(
-                ResourceTestFullController::class,
-                controllerMethod: 'update',
-                httpMethods: 'put',
-                uri: 'posts/{post}',
-                name: 'posts.update'
-            )
-            ->assertRouteRegistered(
-                ResourceTestFullController::class,
-                controllerMethod: 'destroy',
-                httpMethods: 'delete',
-                uri: 'posts/{post}',
-                name: 'posts.destroy'
-            );
-    }
+it('can register resource with all methods', function () {
+    $this->routeRegistrar->registerClass(ResourceTestFullController::class);
 
-    /** @test */
-    public function it_can_register_resource_with_only_few_methods()
-    {
-        $this->routeRegistrar->registerClass(ResourceTestOnlyController::class);
+    $this
+        ->assertRegisteredRoutesCount(7)
+        ->assertRouteRegistered(
+            ResourceTestFullController::class,
+            controllerMethod: 'index',
+            uri: 'posts',
+            name: 'posts.index'
+        )
+        ->assertRouteRegistered(
+            ResourceTestFullController::class,
+            controllerMethod: 'create',
+            uri: 'posts/create',
+            name: 'posts.create'
+        )
+        ->assertRouteRegistered(
+            ResourceTestFullController::class,
+            controllerMethod: 'store',
+            httpMethods: 'post',
+            uri: 'posts',
+            name: 'posts.store'
+        )
+        ->assertRouteRegistered(
+            ResourceTestFullController::class,
+            controllerMethod: 'show',
+            uri: 'posts/{post}',
+            name: 'posts.show'
+        )
+        ->assertRouteRegistered(
+            ResourceTestFullController::class,
+            controllerMethod: 'edit',
+            uri: 'posts/{post}/edit',
+            name: 'posts.edit'
+        )
+        ->assertRouteRegistered(
+            ResourceTestFullController::class,
+            controllerMethod: 'update',
+            httpMethods: 'put',
+            uri: 'posts/{post}',
+            name: 'posts.update'
+        )
+        ->assertRouteRegistered(
+            ResourceTestFullController::class,
+            controllerMethod: 'destroy',
+            httpMethods: 'delete',
+            uri: 'posts/{post}',
+            name: 'posts.destroy'
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(3)
-            ->assertRouteRegistered(
-                ResourceTestOnlyController::class,
-                controllerMethod: 'index',
-                uri: 'posts',
-                name: 'posts.index'
-            )
-            ->assertRouteRegistered(
-                ResourceTestOnlyController::class,
-                controllerMethod: 'store',
-                httpMethods: 'post',
-                uri: 'posts',
-                name: 'posts.store'
-            )
-            ->assertRouteRegistered(
-                ResourceTestOnlyController::class,
-                controllerMethod: 'show',
-                uri: 'posts/{post}',
-                name: 'posts.show'
-            );
-    }
+it('can register resource with only few methods', function () {
+    $this->routeRegistrar->registerClass(ResourceTestOnlyController::class);
 
-    /** @test */
-    public function it_can_register_resource_without_few_methods()
-    {
-        $this->routeRegistrar->registerClass(ResourceTestExceptController::class);
+    $this
+        ->assertRegisteredRoutesCount(3)
+        ->assertRouteRegistered(
+            ResourceTestOnlyController::class,
+            controllerMethod: 'index',
+            uri: 'posts',
+            name: 'posts.index'
+        )
+        ->assertRouteRegistered(
+            ResourceTestOnlyController::class,
+            controllerMethod: 'store',
+            httpMethods: 'post',
+            uri: 'posts',
+            name: 'posts.store'
+        )
+        ->assertRouteRegistered(
+            ResourceTestOnlyController::class,
+            controllerMethod: 'show',
+            uri: 'posts/{post}',
+            name: 'posts.show'
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(5)
-            ->assertRouteRegistered(
-                ResourceTestExceptController::class,
-                controllerMethod: 'index',
-                uri: 'posts',
-                name: 'posts.index'
-            )
-            ->assertRouteRegistered(
-                ResourceTestExceptController::class,
-                controllerMethod: 'create',
-                uri: 'posts/create',
-                name: 'posts.create'
-            )
-            ->assertRouteRegistered(
-                ResourceTestExceptController::class,
-                controllerMethod: 'store',
-                httpMethods: 'post',
-                uri: 'posts',
-                name: 'posts.store'
-            )
-            ->assertRouteRegistered(
-                ResourceTestExceptController::class,
-                controllerMethod: 'show',
-                uri: 'posts/{post}',
-                name: 'posts.show'
-            )
-            ->assertRouteRegistered(
-                ResourceTestExceptController::class,
-                controllerMethod: 'edit',
-                uri: 'posts/{post}/edit',
-                name: 'posts.edit'
-            );
-    }
+it('can register resource without few methods', function () {
+    $this->routeRegistrar->registerClass(ResourceTestExceptController::class);
 
-    /** @test */
-    public function it_can_register_api_resource()
-    {
-        $this->routeRegistrar->registerClass(ResourceTestApiController::class);
+    $this
+        ->assertRegisteredRoutesCount(5)
+        ->assertRouteRegistered(
+            ResourceTestExceptController::class,
+            controllerMethod: 'index',
+            uri: 'posts',
+            name: 'posts.index'
+        )
+        ->assertRouteRegistered(
+            ResourceTestExceptController::class,
+            controllerMethod: 'create',
+            uri: 'posts/create',
+            name: 'posts.create'
+        )
+        ->assertRouteRegistered(
+            ResourceTestExceptController::class,
+            controllerMethod: 'store',
+            httpMethods: 'post',
+            uri: 'posts',
+            name: 'posts.store'
+        )
+        ->assertRouteRegistered(
+            ResourceTestExceptController::class,
+            controllerMethod: 'show',
+            uri: 'posts/{post}',
+            name: 'posts.show'
+        )
+        ->assertRouteRegistered(
+            ResourceTestExceptController::class,
+            controllerMethod: 'edit',
+            uri: 'posts/{post}/edit',
+            name: 'posts.edit'
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(5)
-            ->assertRouteRegistered(
-                ResourceTestApiController::class,
-                controllerMethod: 'index',
-                uri: 'posts',
-                name: 'posts.index'
-            )
-            ->assertRouteRegistered(
-                ResourceTestApiController::class,
-                controllerMethod: 'store',
-                httpMethods: 'post',
-                uri: 'posts',
-                name: 'posts.store'
-            )
-            ->assertRouteRegistered(
-                ResourceTestApiController::class,
-                controllerMethod: 'show',
-                uri: 'posts/{post}',
-                name: 'posts.show'
-            )
-            ->assertRouteRegistered(
-                ResourceTestApiController::class,
-                controllerMethod: 'update',
-                httpMethods: 'put',
-                uri: 'posts/{post}',
-                name: 'posts.update'
-            )
-            ->assertRouteRegistered(
-                ResourceTestApiController::class,
-                controllerMethod: 'destroy',
-                httpMethods: 'delete',
-                uri: 'posts/{post}',
-                name: 'posts.destroy'
-            );
-    }
-}
+it('can register api resource', function () {
+    $this->routeRegistrar->registerClass(ResourceTestApiController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(5)
+        ->assertRouteRegistered(
+            ResourceTestApiController::class,
+            controllerMethod: 'index',
+            uri: 'posts',
+            name: 'posts.index'
+        )
+        ->assertRouteRegistered(
+            ResourceTestApiController::class,
+            controllerMethod: 'store',
+            httpMethods: 'post',
+            uri: 'posts',
+            name: 'posts.store'
+        )
+        ->assertRouteRegistered(
+            ResourceTestApiController::class,
+            controllerMethod: 'show',
+            uri: 'posts/{post}',
+            name: 'posts.show'
+        )
+        ->assertRouteRegistered(
+            ResourceTestApiController::class,
+            controllerMethod: 'update',
+            httpMethods: 'put',
+            uri: 'posts/{post}',
+            name: 'posts.update'
+        )
+        ->assertRouteRegistered(
+            ResourceTestApiController::class,
+            controllerMethod: 'destroy',
+            httpMethods: 'delete',
+            uri: 'posts/{post}',
+            name: 'posts.destroy'
+        );
+});

--- a/tests/AttributeTests/RouteAttributeTest.php
+++ b/tests/AttributeTests/RouteAttributeTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Spatie\RouteAttributes\RouteRegistrar;
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\InvokableRouteGetTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteGetTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteMiddlewareTestController;
@@ -9,7 +7,6 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteMul
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteNameTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RoutePostTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
-
 
 test('the route annotation can register a get route', function () {
     $this->routeRegistrar->registerClass(RouteGetTestController::class);

--- a/tests/AttributeTests/RouteAttributeTest.php
+++ b/tests/AttributeTests/RouteAttributeTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\RouteRegistrar;
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\InvokableRouteGetTestController;
@@ -12,78 +10,63 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteNam
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RoutePostTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
-class RouteAttributeTest extends TestCase
-{
-    protected RouteRegistrar $routeRegistrar;
+uses(TestCase::class);
 
-    /** @test */
-    public function the_route_annotation_can_register_a_get_route_()
-    {
-        $this->routeRegistrar->registerClass(RouteGetTestController::class);
+test('the route annotation can register a get route', function () {
+    $this->routeRegistrar->registerClass(RouteGetTestController::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(RouteGetTestController::class, 'myGetMethod', 'get', 'my-get-method');
-    }
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(RouteGetTestController::class, 'myGetMethod', 'get', 'my-get-method');
+});
 
-    /** @test */
-    public function the_route_annotation_can_register_a_post_route()
-    {
-        $this->routeRegistrar->registerClass(RoutePostTestController::class);
+test('the route annotation can register a post route', function () {
+    $this->routeRegistrar->registerClass(RoutePostTestController::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(RoutePostTestController::class, 'myPostMethod', 'post', 'my-post-method');
-    }
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(RoutePostTestController::class, 'myPostMethod', 'post', 'my-post-method');
+});
 
-    /** @test */
-    public function the_route_annotation_can_register_a_multi_verb_route()
-    {
-        $this->routeRegistrar->registerClass(RouteMultiVerbTestController::class);
+test('the route annotation can register a multi verb route', function () {
+    $this->routeRegistrar->registerClass(RouteMultiVerbTestController::class);
 
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(
-                RouteMultiVerbTestController::class,
-                'myMultiVerbMethod',
-                ['get','post', 'delete'],
-                'my-multi-verb-method'
-            );
-    }
-
-    /** @test */
-    public function it_can_add_middleware_to_a_method()
-    {
-        $this->routeRegistrar->registerClass(RouteMiddlewareTestController::class);
-
-        $this->assertRouteRegistered(
-            controller: RouteMiddlewareTestController::class,
-            middleware: TestMiddleware::class,
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
+            RouteMultiVerbTestController::class,
+            'myMultiVerbMethod',
+            ['get','post', 'delete'],
+            'my-multi-verb-method'
         );
-    }
+});
 
-    /** @test */
-    public function it_can_add_a_route_name_to_a_method()
-    {
-        $this->routeRegistrar->registerClass(RouteNameTestController::class);
+it('can add middleware to a method', function () {
+    $this->routeRegistrar->registerClass(RouteMiddlewareTestController::class);
 
-        $this->assertRouteRegistered(
-            controller: RouteNameTestController::class,
-            name: 'test-name',
+    $this->assertRouteRegistered(
+        controller: RouteMiddlewareTestController::class,
+        middleware: TestMiddleware::class,
+    );
+});
+
+it('can add a route name to a method', function () {
+    $this->routeRegistrar->registerClass(RouteNameTestController::class);
+
+    $this->assertRouteRegistered(
+        controller: RouteNameTestController::class,
+        name: 'test-name',
+    );
+});
+
+it('can add a route for an invokable', function () {
+    $this->routeRegistrar->registerClass(InvokableRouteGetTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
+            controller: InvokableRouteGetTestController::class,
+            controllerMethod: InvokableRouteGetTestController::class,
+            uri: 'my-invokable-route'
         );
-    }
-
-    /** @test */
-    public function it_can_add_a_route_for_an_invokable()
-    {
-        $this->routeRegistrar->registerClass(InvokableRouteGetTestController::class);
-
-        $this
-            ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(
-                controller: InvokableRouteGetTestController::class,
-                controllerMethod: InvokableRouteGetTestController::class,
-                uri: 'my-invokable-route'
-            );
-    }
-}
+});

--- a/tests/AttributeTests/RouteAttributeTest.php
+++ b/tests/AttributeTests/RouteAttributeTest.php
@@ -10,7 +10,6 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RouteNam
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteAttribute\RoutePostTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
-uses(TestCase::class);
 
 test('the route annotation can register a get route', function () {
     $this->routeRegistrar->registerClass(RouteGetTestController::class);

--- a/tests/AttributeTests/WhereAttributeTest.php
+++ b/tests/AttributeTests/WhereAttributeTest.php
@@ -3,7 +3,6 @@
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\WhereTestController;
 
-uses(TestCase::class);
 
 it('can apply where on each method of a controller', function () {
     $this->routeRegistrar->registerClass(WhereTestController::class);

--- a/tests/AttributeTests/WhereAttributeTest.php
+++ b/tests/AttributeTests/WhereAttributeTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\WhereTestController;
-
 
 it('can apply where on each method of a controller', function () {
     $this->routeRegistrar->registerClass(WhereTestController::class);

--- a/tests/AttributeTests/WhereAttributeTest.php
+++ b/tests/AttributeTests/WhereAttributeTest.php
@@ -1,67 +1,58 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\AttributeTests;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\WhereTestController;
 
-class WhereAttributeTest extends TestCase
-{
-    /** @test */
-    public function it_can_apply_where_on_each_method_of_a_controller()
-    {
-        $this->routeRegistrar->registerClass(WhereTestController::class);
+uses(TestCase::class);
 
-        $this
-            ->assertRegisteredRoutesCount(4)
-            ->assertRouteRegistered(
-                WhereTestController::class,
-                controllerMethod: 'myGetMethod',
-                uri: 'my-get-method/{param}',
-                wheres: ['param' => '[0-9]+']
-            )
-            ->assertRouteRegistered(
-                WhereTestController::class,
-                controllerMethod: 'myPostMethod',
-                httpMethods: 'post',
-                uri: 'my-post-method/{param}/{param2}',
-                wheres: ['param' => '[0-9]+', 'param2' => '[a-zA-Z]+']
-            );
-    }
+it('can apply where on each method of a controller', function () {
+    $this->routeRegistrar->registerClass(WhereTestController::class);
 
-    /** @test */
-    public function it_can_apply_where_on_a_method()
-    {
-        $this->routeRegistrar->registerClass(WhereTestController::class);
+    $this
+        ->assertRegisteredRoutesCount(4)
+        ->assertRouteRegistered(
+            WhereTestController::class,
+            controllerMethod: 'myGetMethod',
+            uri: 'my-get-method/{param}',
+            wheres: ['param' => '[0-9]+']
+        )
+        ->assertRouteRegistered(
+            WhereTestController::class,
+            controllerMethod: 'myPostMethod',
+            httpMethods: 'post',
+            uri: 'my-post-method/{param}/{param2}',
+            wheres: ['param' => '[0-9]+', 'param2' => '[a-zA-Z]+']
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(4)
-            ->assertRouteRegistered(
-                WhereTestController::class,
-                controllerMethod: 'myWhereMethod',
-                uri: 'my-where-method/{param}/{param2}/{param3}',
-                wheres: ['param' => '[0-9]+', 'param2' => '[a-zA-Z]+', 'param3' => 'test']
-            );
-    }
+it('can apply where on a method', function () {
+    $this->routeRegistrar->registerClass(WhereTestController::class);
 
-    /** @test */
-    public function it_can_apply_shorthand_where()
-    {
-        $this->routeRegistrar->registerClass(WhereTestController::class);
+    $this
+        ->assertRegisteredRoutesCount(4)
+        ->assertRouteRegistered(
+            WhereTestController::class,
+            controllerMethod: 'myWhereMethod',
+            uri: 'my-where-method/{param}/{param2}/{param3}',
+            wheres: ['param' => '[0-9]+', 'param2' => '[a-zA-Z]+', 'param3' => 'test']
+        );
+});
 
-        $this
-            ->assertRegisteredRoutesCount(4)
-            ->assertRouteRegistered(
-                WhereTestController::class,
-                controllerMethod: 'myShorthands',
-                uri: 'my-shorthands',
-                wheres: [
-                    'param' => '[0-9]+',
-                    'alpha' => '[a-zA-Z]+',
-                    'alpha-numeric' => '[a-zA-Z0-9]+',
-                    'number' => '[0-9]+',
-                    'uuid' => '[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}',
-                ]
-            );
-    }
-}
+it('can apply shorthand where', function () {
+    $this->routeRegistrar->registerClass(WhereTestController::class);
+
+    $this
+        ->assertRegisteredRoutesCount(4)
+        ->assertRouteRegistered(
+            WhereTestController::class,
+            controllerMethod: 'myShorthands',
+            uri: 'my-shorthands',
+            wheres: [
+                'param' => '[0-9]+',
+                'alpha' => '[a-zA-Z]+',
+                'alpha-numeric' => '[a-zA-Z0-9]+',
+                'number' => '[0-9]+',
+                'uuid' => '[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}',
+            ]
+        );
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/underlying-test-case */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/expectations#custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/helpers */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,42 +1,5 @@
 <?php
 
-uses(\Spatie\RouteAttributes\Tests\TestCase::class)->in('tests', 'AttributeTests', 'TestClasses', 'RouteDiscovery');
+use Spatie\RouteAttributes\Tests\TestCase;
 
-/*
-|--------------------------------------------------------------------------
-| Test Case
-|--------------------------------------------------------------------------
-|
-| The closure you provide to your test functions is always bound to a specific PHPUnit test
-| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "uses()" function to bind a different classes or traits.
-|
-*/
-
-/** @link https://pestphp.com/docs/underlying-test-case */
-
-/*
-|--------------------------------------------------------------------------
-| Expectations
-|--------------------------------------------------------------------------
-|
-| When you're writing tests, you often need to check that values meet certain conditions. The
-| "expect()" function gives you access to a set of "expectations" methods that you can use
-| to assert different things. Of course, you may extend the Expectation API at any time.
-|
-*/
-
-/** @link https://pestphp.com/docs/expectations#custom-expectations */
-
-/*
-|--------------------------------------------------------------------------
-| Functions
-|--------------------------------------------------------------------------
-|
-| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
-| project that you don't want to repeat in every file. Here you can also expose helpers as
-| global functions to help you to reduce the number of lines of code in your test files.
-|
-*/
-
-/** @link https://pestphp.com/docs/helpers */
+uses(TestCase::class)->in(__DIR__);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+uses(\Spatie\RouteAttributes\Tests\TestCase::class)->in('tests', 'AttributeTests', 'TestClasses', 'RouteDiscovery');
+
 /*
 |--------------------------------------------------------------------------
 | Test Case

--- a/tests/RouteDiscovery/DiscoverControllerTest.php
+++ b/tests/RouteDiscovery/DiscoverControllerTest.php
@@ -6,7 +6,6 @@ use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\CustomMethod\CustomMethodController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\SingleController\MyController;
 
-uses(TestCase::class);
 
 it('can discover controller in a directory', function () {
     Discover::controllers()

--- a/tests/RouteDiscovery/DiscoverControllerTest.php
+++ b/tests/RouteDiscovery/DiscoverControllerTest.php
@@ -2,10 +2,8 @@
 
 use Illuminate\Support\Facades\Route;
 use Spatie\RouteAttributes\RouteDiscovery\Discover;
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\CustomMethod\CustomMethodController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\SingleController\MyController;
-
 
 it('can discover controller in a directory', function () {
     Discover::controllers()

--- a/tests/RouteDiscovery/DiscoverControllerTest.php
+++ b/tests/RouteDiscovery/DiscoverControllerTest.php
@@ -1,65 +1,59 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\RouteDiscovery;
-
 use Illuminate\Support\Facades\Route;
 use Spatie\RouteAttributes\RouteDiscovery\Discover;
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\CustomMethod\CustomMethodController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\SingleController\MyController;
 
-class DiscoverControllerTest extends TestCase
+uses(TestCase::class);
+
+it('can discover controller in a directory', function () {
+    Discover::controllers()
+        ->useRootNamespace('Spatie\RouteAttributes\Tests\\')
+        ->useBasePath($this->getTestPath())
+        ->in($this->getTestPath('TestClasses/AutoDiscovery/SingleController'));
+
+    $this->assertRegisteredRoutesCount(1);
+
+    $this->assertRouteRegistered(
+        MyController::class,
+        controllerMethod: 'index',
+        uri: 'my',
+    );
+});
+
+it('can discover controllers with custom methods', function () {
+    Discover::controllers()
+        ->useRootNamespace('Spatie\RouteAttributes\Tests\\')
+        ->useBasePath($this->getTestPath())
+        ->in($this->getTestPath('TestClasses/AutoDiscovery/CustomMethod'));
+
+    $this->assertRegisteredRoutesCount(1);
+
+    $this->assertRouteRegistered(
+        CustomMethodController::class,
+        controllerMethod: 'myCustomMethod',
+        uri: 'custom-method/my-custom-method'
+    );
+});
+
+// Helpers
+function it_can_use_a_prefix_when_discovering_routes()
 {
-    /** @test */
-    public function it_can_discover_controller_in_a_directory()
-    {
+    Route::prefix('my-prefix')->group(function () {
         Discover::controllers()
             ->useRootNamespace('Spatie\RouteAttributes\Tests\\')
-            ->useBasePath($this->getTestPath())
-            ->in($this->getTestPath('TestClasses/AutoDiscovery/SingleController'));
+            ->useBasePath(test()->getTestPath())
+            ->in(test()->getTestPath('TestClasses/AutoDiscovery/SingleController'));
+    });
 
-        $this->assertRegisteredRoutesCount(1);
-
-        $this->assertRouteRegistered(
-            MyController::class,
-            controllerMethod: 'index',
-            uri: 'my',
-        );
-    }
-
-    public function it_can_use_a_prefix_when_discovering_routes()
-    {
-        Route::prefix('my-prefix')->group(function () {
-            Discover::controllers()
-                ->useRootNamespace('Spatie\RouteAttributes\Tests\\')
-                ->useBasePath($this->getTestPath())
-                ->in($this->getTestPath('TestClasses/AutoDiscovery/SingleController'));
-        });
-
-        $this->assertRegisteredRoutesCount(1);
+    test()->assertRegisteredRoutesCount(1);
 
 
-        $this->assertRouteRegistered(
-            MyController::class,
-            controllerMethod: 'index',
-            uri: 'my',
-        );
-    }
-
-    /** @test */
-    public function it_can_discover_controllers_with_custom_methods()
-    {
-        Discover::controllers()
-            ->useRootNamespace('Spatie\RouteAttributes\Tests\\')
-            ->useBasePath($this->getTestPath())
-            ->in($this->getTestPath('TestClasses/AutoDiscovery/CustomMethod'));
-
-        $this->assertRegisteredRoutesCount(1);
-
-        $this->assertRouteRegistered(
-            CustomMethodController::class,
-            controllerMethod: 'myCustomMethod',
-            uri: 'custom-method/my-custom-method'
-        );
-    }
+    test()->assertRouteRegistered(
+        MyController::class,
+        controllerMethod: 'index',
+        uri: 'my',
+    );
 }

--- a/tests/RouteDiscovery/DiscoverControllerTest.php
+++ b/tests/RouteDiscovery/DiscoverControllerTest.php
@@ -11,9 +11,9 @@ it('can discover controller in a directory', function () {
         ->useBasePath($this->getTestPath())
         ->in($this->getTestPath('TestClasses/AutoDiscovery/SingleController'));
 
-    $this->assertRegisteredRoutesCount(1);
-
-    $this->assertRouteRegistered(
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
         MyController::class,
         controllerMethod: 'index',
         uri: 'my',
@@ -26,18 +26,16 @@ it('can discover controllers with custom methods', function () {
         ->useBasePath($this->getTestPath())
         ->in($this->getTestPath('TestClasses/AutoDiscovery/CustomMethod'));
 
-    $this->assertRegisteredRoutesCount(1);
-
-    $this->assertRouteRegistered(
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
         CustomMethodController::class,
         controllerMethod: 'myCustomMethod',
         uri: 'custom-method/my-custom-method'
     );
 });
 
-// Helpers
-function it_can_use_a_prefix_when_discovering_routes()
-{
+it('can use a prefix when discovering routes', function() {
     Route::prefix('my-prefix')->group(function () {
         Discover::controllers()
             ->useRootNamespace('Spatie\RouteAttributes\Tests\\')
@@ -45,12 +43,11 @@ function it_can_use_a_prefix_when_discovering_routes()
             ->in(test()->getTestPath('TestClasses/AutoDiscovery/SingleController'));
     });
 
-    test()->assertRegisteredRoutesCount(1);
-
-
-    test()->assertRouteRegistered(
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
         MyController::class,
         controllerMethod: 'index',
-        uri: 'my',
+        uri: 'my-prefix/my',
     );
-}
+});

--- a/tests/RouteDiscovery/DiscoverViewsTest.php
+++ b/tests/RouteDiscovery/DiscoverViewsTest.php
@@ -4,7 +4,6 @@ use Illuminate\Routing\ViewController;
 use Spatie\RouteAttributes\RouteDiscovery\Discover;
 use Spatie\RouteAttributes\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can discover views in a directory', function () {
     Discover::views()->in($this->getTestPath('TestClasses/resources/views'));

--- a/tests/RouteDiscovery/DiscoverViewsTest.php
+++ b/tests/RouteDiscovery/DiscoverViewsTest.php
@@ -2,8 +2,6 @@
 
 use Illuminate\Routing\ViewController;
 use Spatie\RouteAttributes\RouteDiscovery\Discover;
-use Spatie\RouteAttributes\Tests\TestCase;
-
 
 it('can discover views in a directory', function () {
     Discover::views()->in($this->getTestPath('TestClasses/resources/views'));

--- a/tests/RouteDiscovery/DiscoverViewsTest.php
+++ b/tests/RouteDiscovery/DiscoverViewsTest.php
@@ -1,33 +1,28 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\RouteDiscovery;
-
 use Illuminate\Routing\ViewController;
 use Spatie\RouteAttributes\RouteDiscovery\Discover;
 use Spatie\RouteAttributes\Tests\TestCase;
 
-class DiscoverViewsTest extends TestCase
-{
-    /** @test */
-    public function it_can_discover_views_in_a_directory()
-    {
-        Discover::views()->in($this->getTestPath('TestClasses/resources/views'));
+uses(TestCase::class);
 
-        $this->assertRegisteredRoutesCount(6);
+it('can discover views in a directory', function () {
+    Discover::views()->in($this->getTestPath('TestClasses/resources/views'));
 
-        collect([
-            '/',
-            'home',
-            'long-name',
-            'contact',
-            'nested',
-            'nested/another',
-        ])->each(function (string $uri) {
-            $this->assertRouteRegistered(
-                ViewController::class,
-                controllerMethod: '\\' . ViewController::class,
-                uri: $uri,
-            );
-        });
-    }
-}
+    $this->assertRegisteredRoutesCount(6);
+
+    collect([
+        '/',
+        'home',
+        'long-name',
+        'contact',
+        'nested',
+        'nested/another',
+    ])->each(function (string $uri) {
+        $this->assertRouteRegistered(
+            ViewController::class,
+            controllerMethod: '\\' . ViewController::class,
+            uri: $uri,
+        );
+    });
+});

--- a/tests/RouteDiscovery/RouteDiscoveryTest.php
+++ b/tests/RouteDiscovery/RouteDiscoveryTest.php
@@ -1,13 +1,11 @@
 <?php
 
-use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\ControllerWithNonPublicMethods\NonPublicMethodsController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\ModelController\ModelController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\NestedController\Nested\ChildController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\NestedController\ParentController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\RouteName\CustomRouteNameController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\SingleController\MyController;
-
 
 it('can automatically discovery a simple route', function () {
     $this

--- a/tests/RouteDiscovery/RouteDiscoveryTest.php
+++ b/tests/RouteDiscovery/RouteDiscoveryTest.php
@@ -60,13 +60,13 @@ it('can automatically discovery a model route', function () {
         ->routeRegistrar
         ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/ModelController'));
 
-    $this->assertRegisteredRoutesCount(1);
-
-    $this->assertRouteRegistered(
-        ModelController::class,
-        controllerMethod: 'edit',
-        uri: 'model/{user}',
-    );
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
+            ModelController::class,
+            controllerMethod: 'edit',
+            uri: 'model/{user}',
+        );
 });
 
 it('will only automatically register public methods', function () {
@@ -74,11 +74,11 @@ it('will only automatically register public methods', function () {
         ->routeRegistrar
         ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/ControllerWithNonPublicMethods'));
 
-    $this->assertRegisteredRoutesCount(1);
-
-    $this->assertRouteRegistered(
-        NonPublicMethodsController::class,
-        controllerMethod: 'index',
-        uri: 'non-public-methods',
-    );
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
+            NonPublicMethodsController::class,
+            controllerMethod: 'index',
+            uri: 'non-public-methods',
+        );
 });

--- a/tests/RouteDiscovery/RouteDiscoveryTest.php
+++ b/tests/RouteDiscovery/RouteDiscoveryTest.php
@@ -8,7 +8,6 @@ use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\NestedController\Pare
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\RouteName\CustomRouteNameController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\SingleController\MyController;
 
-uses(TestCase::class);
 
 it('can automatically discovery a simple route', function () {
     $this

--- a/tests/RouteDiscovery/RouteDiscoveryTest.php
+++ b/tests/RouteDiscovery/RouteDiscoveryTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests\RouteDiscovery;
-
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\ControllerWithNonPublicMethods\NonPublicMethodsController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\ModelController\ModelController;
@@ -10,91 +8,80 @@ use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\NestedController\Pare
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\RouteName\CustomRouteNameController;
 use Spatie\RouteAttributes\Tests\TestClasses\AutoDiscovery\SingleController\MyController;
 
-class RouteDiscoveryTest extends TestCase
-{
-    /** @test */
-    public function it_can_automatically_discovery_a_simple_route()
-    {
-        $this
-            ->routeRegistrar
-            ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/SingleController'));
+uses(TestCase::class);
 
-        $this->assertRegisteredRoutesCount(1);
+it('can automatically discovery a simple route', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/SingleController'));
 
-        $this->assertRouteRegistered(
-            MyController::class,
-            controllerMethod: 'index',
-            uri: 'my',
-        );
-    }
+    $this->assertRegisteredRoutesCount(1);
 
-    /** @test */
-    public function it_can_automatically_discovery_a_route_with_a_custom_name()
-    {
-        $this
-            ->routeRegistrar
-            ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/RouteName'));
-        $this->assertRegisteredRoutesCount(1);
+    $this->assertRouteRegistered(
+        MyController::class,
+        controllerMethod: 'index',
+        uri: 'my',
+    );
+});
 
-        $this->assertRouteRegistered(
-            CustomRouteNameController::class,
-            controllerMethod: 'index',
-            uri: 'custom-route-name',
-            name: 'this-is-a-custom-name',
-        );
-    }
+it('can automatically discovery a route with a custom name', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/RouteName'));
+    $this->assertRegisteredRoutesCount(1);
 
-    /** @test */
-    public function it_can_automatically_discover_a_nested_route()
-    {
-        $this
-            ->routeRegistrar
-            ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/NestedController'));
+    $this->assertRouteRegistered(
+        CustomRouteNameController::class,
+        controllerMethod: 'index',
+        uri: 'custom-route-name',
+        name: 'this-is-a-custom-name',
+    );
+});
 
-        $this->assertRegisteredRoutesCount(2);
+it('can automatically discover a nested route', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/NestedController'));
 
-        $this->assertRouteRegistered(
-            ParentController::class,
-            controllerMethod: 'index',
-            uri: 'parent',
-        );
+    $this->assertRegisteredRoutesCount(2);
 
-        $this->assertRouteRegistered(
-            ChildController::class,
-            controllerMethod: 'index',
-            uri: 'nested/child',
-        );
-    }
+    $this->assertRouteRegistered(
+        ParentController::class,
+        controllerMethod: 'index',
+        uri: 'parent',
+    );
 
-    /** @test */
-    public function it_can_automatically_discovery_a_model_route()
-    {
-        $this
-            ->routeRegistrar
-            ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/ModelController'));
+    $this->assertRouteRegistered(
+        ChildController::class,
+        controllerMethod: 'index',
+        uri: 'nested/child',
+    );
+});
 
-        $this->assertRegisteredRoutesCount(1);
+it('can automatically discovery a model route', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/ModelController'));
 
-        $this->assertRouteRegistered(
-            ModelController::class,
-            controllerMethod: 'edit',
-            uri: 'model/{user}',
-        );
-    }
+    $this->assertRegisteredRoutesCount(1);
 
-    /** @test */
-    public function it_will_only_automatically_register_public_methods()
-    {
-        $this
-            ->routeRegistrar
-            ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/ControllerWithNonPublicMethods'));
+    $this->assertRouteRegistered(
+        ModelController::class,
+        controllerMethod: 'edit',
+        uri: 'model/{user}',
+    );
+});
 
-        $this->assertRegisteredRoutesCount(1);
+it('will only automatically register public methods', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory($this->getTestPath('TestClasses/AutoDiscovery/ControllerWithNonPublicMethods'));
 
-        $this->assertRouteRegistered(
-            NonPublicMethodsController::class,
-            controllerMethod: 'index',
-            uri: 'non-public-methods',
-        );
-    }
-}
+    $this->assertRegisteredRoutesCount(1);
+
+    $this->assertRouteRegistered(
+        NonPublicMethodsController::class,
+        controllerMethod: 'index',
+        uri: 'non-public-methods',
+    );
+});

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -1,67 +1,58 @@
 <?php
 
-namespace Spatie\RouteAttributes\Tests;
-
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestFirstController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestSecondController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\SubDirectory\RegistrarTestControllerInSubDirectory;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
 
-class RouteRegistrarTest extends TestCase
-{
-    /** @test */
-    public function the_registrar_can_register_a_single_file()
-    {
-        $this
-            ->routeRegistrar
-            ->registerFile($this->getTestPath('TestClasses/Controllers/RouteRegistrar/RegistrarTestFirstController.php'));
+uses(TestCase::class);
 
-        $this->assertRegisteredRoutesCount(1);
+test('the registrar can register a single file', function () {
+    $this
+        ->routeRegistrar
+        ->registerFile($this->getTestPath('TestClasses/Controllers/RouteRegistrar/RegistrarTestFirstController.php'));
 
-        $this->assertRouteRegistered(
-            RegistrarTestFirstController::class,
-            uri: 'first-method',
-        );
-    }
+    $this->assertRegisteredRoutesCount(1);
 
-    /** @test */
-    public function the_registrar_can_apply_config_middlewares_to_all_routes()
-    {
-        $this
-            ->routeRegistrar
-            ->registerFile($this->getTestPath('TestClasses/Controllers/RouteRegistrar/RegistrarTestFirstController.php'));
+    $this->assertRouteRegistered(
+        RegistrarTestFirstController::class,
+        uri: 'first-method',
+    );
+});
 
-        $this->assertRegisteredRoutesCount(1);
+test('the registrar can apply config middlewares to all routes', function () {
+    $this
+        ->routeRegistrar
+        ->registerFile($this->getTestPath('TestClasses/Controllers/RouteRegistrar/RegistrarTestFirstController.php'));
 
-        $this->assertRouteRegistered(
-            RegistrarTestFirstController::class,
-            uri: 'first-method',
-            middleware: [AnotherTestMiddleware::class]
-        );
-    }
+    $this->assertRegisteredRoutesCount(1);
 
-    /** @test */
-    public function the_registrar_can_register_a_whole_directory()
-    {
-        $this
-            ->routeRegistrar
-            ->registerDirectory($this->getTestPath('TestClasses/Controllers/RouteRegistrar'));
+    $this->assertRouteRegistered(
+        RegistrarTestFirstController::class,
+        uri: 'first-method',
+        middleware: [AnotherTestMiddleware::class]
+    );
+});
 
-        $this->assertRegisteredRoutesCount(3);
+test('the registrar can register a whole directory', function () {
+    $this
+        ->routeRegistrar
+        ->registerDirectory($this->getTestPath('TestClasses/Controllers/RouteRegistrar'));
 
-        $this->assertRouteRegistered(
-            RegistrarTestFirstController::class,
-            uri: 'first-method',
-        );
+    $this->assertRegisteredRoutesCount(3);
 
-        $this->assertRouteRegistered(
-            RegistrarTestSecondController::class,
-            uri: 'second-method',
-        );
+    $this->assertRouteRegistered(
+        RegistrarTestFirstController::class,
+        uri: 'first-method',
+    );
 
-        $this->assertRouteRegistered(
-            RegistrarTestControllerInSubDirectory::class,
-            uri: 'in-sub-directory',
-        );
-    }
-}
+    $this->assertRouteRegistered(
+        RegistrarTestSecondController::class,
+        uri: 'second-method',
+    );
+
+    $this->assertRouteRegistered(
+        RegistrarTestControllerInSubDirectory::class,
+        uri: 'in-sub-directory',
+    );
+});

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -5,8 +5,6 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\Registra
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\SubDirectory\RegistrarTestControllerInSubDirectory;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
 
-uses(TestCase::class);
-
 test('the registrar can register a single file', function () {
     $this
         ->routeRegistrar
@@ -25,13 +23,13 @@ test('the registrar can apply config middlewares to all routes', function () {
         ->routeRegistrar
         ->registerFile($this->getTestPath('TestClasses/Controllers/RouteRegistrar/RegistrarTestFirstController.php'));
 
-    $this->assertRegisteredRoutesCount(1);
-
-    $this->assertRouteRegistered(
-        RegistrarTestFirstController::class,
-        uri: 'first-method',
-        middleware: [AnotherTestMiddleware::class]
-    );
+    $this
+        ->assertRegisteredRoutesCount(1)
+        ->assertRouteRegistered(
+            RegistrarTestFirstController::class,
+            uri: 'first-method',
+            middleware: [AnotherTestMiddleware::class]
+        );
 });
 
 test('the registrar can register a whole directory', function () {
@@ -39,20 +37,18 @@ test('the registrar can register a whole directory', function () {
         ->routeRegistrar
         ->registerDirectory($this->getTestPath('TestClasses/Controllers/RouteRegistrar'));
 
-    $this->assertRegisteredRoutesCount(3);
-
-    $this->assertRouteRegistered(
-        RegistrarTestFirstController::class,
-        uri: 'first-method',
-    );
-
-    $this->assertRouteRegistered(
-        RegistrarTestSecondController::class,
-        uri: 'second-method',
-    );
-
-    $this->assertRouteRegistered(
-        RegistrarTestControllerInSubDirectory::class,
-        uri: 'in-sub-directory',
-    );
+    $this
+        ->assertRegisteredRoutesCount(3)
+        ->assertRouteRegistered(
+            RegistrarTestFirstController::class,
+            uri: 'first-method',
+        )
+        ->assertRouteRegistered(
+            RegistrarTestSecondController::class,
+            uri: 'second-method',
+        )
+        ->assertRouteRegistered(
+            RegistrarTestControllerInSubDirectory::class,
+            uri: 'in-sub-directory',
+        );
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,7 @@ class TestCase extends Orchestra
 {
     protected RouteRegistrar $routeRegistrar;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-53383` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
