### PR TITLE
Namespaced controller directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ return [
 ];
 ```
 
+For controllers outside of the applications root namespace directories can also be added usin a `namespace => path` pattern in the directories array. In the following example controllers from `Modules\Admin\Http\Controllers` will be included.
+
+```php
+'directories' => [
+    'Modules\Admin\Http\Controllers\\' => base_path('admin-module/Http/Controllers'),
+    app_path('Http/Controllers'),
+],
+```
+
 ## Usage
 
 The package provides several annotations that should be put on controller classes and methods. These annotations will be used to automatically register routes

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -6,6 +6,7 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\Registra
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestSecondController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\SubDirectory\RegistrarTestControllerInSubDirectory;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
+use ThirdParty\Http\Controllers\ThirdPartyController;
 
 class RouteRegistrarTest extends TestCase
 {
@@ -62,6 +63,23 @@ class RouteRegistrarTest extends TestCase
         $this->assertRouteRegistered(
             RegistrarTestControllerInSubDirectory::class,
             uri: 'in-sub-directory',
+        );
+    }
+
+    /** @test */
+    public function the_register_can_register_a_directory_with_defined_namespace()
+    {
+        require_once(__DIR__ . '/ThirdPartyTestClasses/Controllers/ThirdPartyController.php');
+        $this->routeRegistrar
+            ->useBasePath(__DIR__ . '/ThirdPartyTestClasses/Controllers')
+            ->useRootNamespace('ThirdParty\Http\Controllers\\')
+            ->registerDirectory(__DIR__ . '/ThirdPartyTestClasses/Controllers');
+
+        $this->assertRegisteredRoutesCount(1);
+        $this->assertRouteRegistered(
+            ThirdPartyController::class,
+            uri: 'third-party',
+            controllerMethod: 'thirdPartyGetMethod',
         );
     }
 }

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -71,9 +71,9 @@ class RouteRegistrarTest extends TestCase
     {
         require_once(__DIR__ . '/ThirdPartyTestClasses/Controllers/ThirdPartyController.php');
         $this->routeRegistrar
-            ->useBasePath(__DIR__ . '/ThirdPartyTestClasses/Controllers')
+            ->useBasePath($this->getTestPath('ThirdPartyTestClasses' . DIRECTORY_SEPARATOR . 'Controllers'))
             ->useRootNamespace('ThirdParty\Http\Controllers\\')
-            ->registerDirectory(__DIR__ . '/ThirdPartyTestClasses/Controllers');
+            ->registerDirectory($this->getTestPath('ThirdPartyTestClasses' . DIRECTORY_SEPARATOR . 'Controllers'));
 
         $this->assertRegisteredRoutesCount(1);
         $this->assertRouteRegistered(

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -67,7 +67,7 @@ class RouteRegistrarTest extends TestCase
     }
 
     /** @test */
-    public function the_register_can_register_a_directory_with_defined_namespace()
+    public function the_registrar_can_register_a_directory_with_defined_namespace()
     {
         require_once(__DIR__ . '/ThirdPartyTestClasses/Controllers/ThirdPartyController.php');
         $this->routeRegistrar

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,7 +35,7 @@ class TestCase extends Orchestra
 
     public function getTestPath(string $directory = null): string
     {
-        return __DIR__ . ($directory ? '/' . $directory : '');
+        return __DIR__ . ($directory ? DIRECTORY_SEPARATOR . $directory : '');
     }
 
     public function assertRegisteredRoutesCount(int $expectedNumber): self

--- a/tests/ThirdPartyTestClasses/Controllers/ThirdPartyController.php
+++ b/tests/ThirdPartyTestClasses/Controllers/ThirdPartyController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ThirdParty\Http\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Get;
+
+class ThirdPartyController
+{
+
+    #[Get('third-party')]
+    public function thirdPartyGetMethod()
+    {
+    }
+
+}


### PR DESCRIPTION
As discussed #68 and #59 there is sometimes a need to define a path of controllers using a root namespace outside of the application's namespace.

By also supplying a root namespace with the directory path this can be achieved with, as it turns out, pretty small changes.

Details to consider, and perhaps discuss:
 - In this case, the `RouteRegistrar::basePath` will always be the same as whatever directory you supply in the config (running `RouteRegistrar::registerDirectory()`). This makes me think that the base path property is redundant. I opted to not make any changes in the RouteRegistrar however, as it could be considered out of scope.
 - Testing this is pretty ugly, as the test must load a class from outside the test namespace. I opted to manually require a "third party" controller in the test, as it felt like the most contained way of doing the test. Although it could be argued that the test itself is redundant - it's really just doing what `TestCase::setUp()` does, but with different inputs to the route registrar. 
