### PR TITLE
Fixes implicit route model binding bug when using Resource attribute.

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -140,9 +140,7 @@ class RouteRegistrar
                 $route->names($names);
             }
 
-            if ($middleware = $classRouteAttributes->middleware()) {
-                $route->middleware([...$this->middleware, ...$middleware]);
-            }
+            $route->middleware([...$this->middleware, ...$classRouteAttributes->middleware()]);
         });
     }
 

--- a/tests/AttributeTests/ResourceAttributeTest.php
+++ b/tests/AttributeTests/ResourceAttributeTest.php
@@ -12,6 +12,7 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestNa
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestNamesStringController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestOnlyController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestPrefixController;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
 
@@ -58,6 +59,37 @@ class ResourceAttributeTest extends TestCase
                 uri: 'posts/{post}',
                 middleware: [TestMiddleware::class, OtherTestMiddleware::class],
                 name: 'posts.show',
+            );
+    }
+
+    /** @test */
+    public function it_can_register_resource_with_only_default_middleware()
+    {
+        $this->routeRegistrar->registerClass(ResourceTestOnlyController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(3)
+            ->assertRouteRegistered(
+                ResourceTestOnlyController::class,
+                controllerMethod: 'index',
+                uri: 'posts',
+                middleware: [AnotherTestMiddleware::class],
+                name: 'posts.index'
+            )
+            ->assertRouteRegistered(
+                ResourceTestOnlyController::class,
+                controllerMethod: 'store',
+                httpMethods: 'post',
+                uri: 'posts',
+                middleware: [AnotherTestMiddleware::class],
+                name: 'posts.store'
+            )
+            ->assertRouteRegistered(
+                ResourceTestOnlyController::class,
+                controllerMethod: 'show',
+                uri: 'posts/{post}',
+                middleware: [AnotherTestMiddleware::class],
+                name: 'posts.show'
             );
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -83,7 +83,7 @@ class TestCase extends Orchestra
                     return false;
                 }
 
-                if (array_diff($route->middleware(), array_merge($middleware, $this->routeRegistrar->middleware()))) {
+                if (array_diff(array_merge($middleware, $this->routeRegistrar->middleware()), $route->middleware())) {
                     return false;
                 }
 


### PR DESCRIPTION
Hi @freekmurze 

This should fix #76. 

When registering a resource, it would only add middleware to the route when it would be explicitly defined, which meant that the default `SubstituteBindings` middleware was never being applied unless you also defined other middleware.

Also the check in the tests where an `array_diff` is done to make sure the middleware is present in the request was in the wrong order, resulting in always true.