### PR TITLE
feat: add Fallback attribute

### DIFF
--- a/src/Attributes/Fallback.php
+++ b/src/Attributes/Fallback.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\RouteAttributes\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Fallback
+{
+    public function __construct() {
+    }
+}

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionAttribute;
 use ReflectionClass;
+use Spatie\RouteAttributes\Attributes\Fallback;
 use Spatie\RouteAttributes\Attributes\Route;
 use Spatie\RouteAttributes\Attributes\RouteAttribute;
 use Spatie\RouteAttributes\Attributes\Where;

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -149,6 +149,7 @@ class RouteRegistrar
         foreach ($class->getMethods() as $method) {
             $attributes = $method->getAttributes(RouteAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
             $wheresAttributes = $method->getAttributes(WhereAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
+            $fallbackAttributes = $method->getAttributes(Fallback::class, ReflectionAttribute::IS_INSTANCEOF);
 
             foreach ($attributes as $attribute) {
                 try {
@@ -185,6 +186,10 @@ class RouteRegistrar
                 $classMiddleware = $classRouteAttributes->middleware();
                 $methodMiddleware = $attributeClass->middleware;
                 $route->middleware([...$this->middleware, ...$classMiddleware, ...$methodMiddleware]);
+
+                if (count($fallbackAttributes) > 0) {
+                    $route->fallback();
+                }
             }
         }
     }

--- a/tests/AttributeTests/FallbackAttributeTest.php
+++ b/tests/AttributeTests/FallbackAttributeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\AttributeTests;
+
+use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\FallbackTestController;
+
+class FallbackAttributeTest extends TestCase
+{
+    /** @test */
+    public function it_can_register_a_route_as_fallback()
+    {
+        $this->routeRegistrar->registerClass(FallbackTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(1)
+            ->assertRouteRegistered(FallbackTestController::class, 'myFallbackMethod', 'get', 'my-fallback-method', [], null, null, [], true);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -55,14 +55,15 @@ class TestCase extends Orchestra
         string | array $middleware = [],
         ?string $name = null,
         ?string $domain = null,
-        ?array $wheres = []
+        ?array $wheres = [],
+        ?bool $isFallback = false
     ): self {
         if (! is_array($middleware)) {
             $middleware = Arr::wrap($middleware);
         }
 
         $routeRegistered = collect($this->getRouteCollection()->getRoutes())
-            ->contains(function (Route $route) use ($name, $middleware, $controllerMethod, $controller, $uri, $httpMethods, $domain, $wheres) {
+            ->contains(function (Route $route) use ($name, $middleware, $controllerMethod, $controller, $uri, $httpMethods, $domain, $wheres, $isFallback) {
                 foreach (Arr::wrap($httpMethods) as $httpMethod) {
                     if (! in_array(strtoupper($httpMethod), $route->methods)) {
                         return false;
@@ -96,6 +97,10 @@ class TestCase extends Orchestra
                 }
 
                 if ($wheres !== $route->wheres) {
+                    return false;
+                }
+
+                if ($route->isFallback !== $isFallback) {
                     return false;
                 }
 

--- a/tests/TestClasses/Controllers/FallbackTestController.php
+++ b/tests/TestClasses/Controllers/FallbackTestController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Fallback;
+use Spatie\RouteAttributes\Attributes\Get;
+
+class FallbackTestController
+{
+    #[Get('my-fallback-method')]
+    #[Fallback]
+    public function myFallbackMethod()
+    {
+    }
+}


### PR DESCRIPTION
This PR adds a `Fallback` attribute that can be used to define fallback routes.