### PR TITLE
fix: make order of routes predictable

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -62,7 +62,7 @@ class RouteRegistrar
     {
         $directories = Arr::wrap($directories);
 
-        $files = (new Finder())->files()->name('*.php')->in($directories);
+        $files = (new Finder())->files()->name('*.php')->in($directories)->sortByName();
 
         collect($files)->each(fn (SplFileInfo $file) => $this->registerFile($file));
     }


### PR DESCRIPTION
Currently, the order of routes is not really predictable. Sorting them by controller's file names always guarantees the same order.