### PR TITLE
feat: add grouped configurations and improve tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,19 +66,20 @@ return [
     /*
      * Controllers in these directories that have routing attributes
      * will automatically be registered.
+     *
+     * Optionally, you can pass middleware by passes key/values
      */
     'directories' => [
         app_path('Http/Controllers'),
-        /*
-         *  Alternative syntax to segment by subdirectory with global group options
-         */
+
         app_path('Http/Controllers/Web') => [
             'middleware' => ['web']
-        ]
+        ],
+        
         app_path('Http/Controllers/Api') => [
             'prefix' => 'api',
             'middleware' => 'api'
-        ]
+        ],
     ],
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -69,15 +69,29 @@ return [
      */
     'directories' => [
         app_path('Http/Controllers'),
+        /*
+         *  Alternative syntax to segment by subdirectory with global group options
+         */
+        app_path('Http/Controllers/Web') => [
+            'middleware' => ['web']
+        ]
+        app_path('Http/Controllers/Api') => [
+            'prefix' => 'api',
+            'middleware' => 'api'
+        ]
     ],
 ];
 ```
 
-For controllers outside of the applications root namespace directories can also be added usin a `namespace => path` pattern in the directories array. In the following example controllers from `Modules\Admin\Http\Controllers` will be included.
+For controllers outside of the applications root namespace directories can also be added using a `namespace => path` pattern in the directories array. In the following example controllers from `Modules\Admin\Http\Controllers` will be included.
 
 ```php
 'directories' => [
     'Modules\Admin\Http\Controllers\\' => base_path('admin-module/Http/Controllers'),
+    // Or
+    base_path('admin-module/Http/Controllers') => [
+        'namespace' => 'Modules\Admin\Http\Controllers\\'
+    ],
     app_path('Http/Controllers'),
 ],
 ```

--- a/config/route-attributes.php
+++ b/config/route-attributes.php
@@ -9,16 +9,17 @@ return [
     /*
      * Controllers in these directories that have routing attributes
      * will automatically be registered.
+     *
+     * Optionally, you can pass middleware by passes key/values
      */
     'directories' => [
         app_path('Http/Controllers'),
         /*
-         *  Alternative syntax to register by directory with global options
-         */
-        //app_path('Http/Controllers/Api') => [
-        //    'prefix' => 'api',
-        //    'middleware' => 'api'
-        //]
+        app_path('Http/Controllers/Api') => [
+           'prefix' => 'api',
+           'middleware' => 'api',
+        ],
+        /*
     ],
 
     /**

--- a/config/route-attributes.php
+++ b/config/route-attributes.php
@@ -19,7 +19,7 @@ return [
            'prefix' => 'api',
            'middleware' => 'api',
         ],
-        /*
+        */
     ],
 
     /**

--- a/config/route-attributes.php
+++ b/config/route-attributes.php
@@ -12,6 +12,13 @@ return [
      */
     'directories' => [
         app_path('Http/Controllers'),
+        /*
+         *  Alternative syntax to register by directory with global options
+         */
+        //app_path('Http/Controllers/Api') => [
+        //    'prefix' => 'api',
+        //    'middleware' => 'api'
+        //]
     ],
 
     /**

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -38,7 +38,7 @@ class RouteAttributesServiceProvider extends ServiceProvider
 
                 $routeRegistrar
                     ->useRootNamespace($directory['namespace'] ?? app()->getNamespace())
-                    ->useBasePath($directory['base_path'] ?? (isset($directory['namespace']) ? $namespace : app()->basePath()))
+                    ->useBasePath($directory['base_path'] ?? (isset($directory['namespace']) ? $namespace : app()->path()))
                     ->group($options, fn () => $routeRegistrar->registerDirectory($namespace));
             } else {
                 is_string($namespace)

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -32,15 +32,13 @@ class RouteAttributesServiceProvider extends ServiceProvider
         $routeRegistrar = (new RouteRegistrar(app()->router))
             ->useMiddleware(config('route-attributes.middleware') ?? []);
 
-        $this->app->singleton(RouteRegistrar::class, fn () => $routeRegistrar);
-
         collect($this->getRouteDirectories())->each(function (string|array $directory, string|int $namespace) use ($routeRegistrar) {
             if (is_array($directory)) {
                 $options = Arr::except($directory, ['namespace', 'base_path']);
 
                 $routeRegistrar
                     ->useRootNamespace($directory['namespace'] ?? app()->getNamespace())
-                    ->useBasePath($directory['base_path'] ?? $namespace)
+                    ->useBasePath($directory['base_path'] ?? isset($directory['namespace']) ? $namespace : app()->basePath())
                     ->group($options, fn () => $routeRegistrar->registerDirectory($namespace));
             } else {
                 is_string($namespace)

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -38,7 +38,7 @@ class RouteAttributesServiceProvider extends ServiceProvider
 
                 $routeRegistrar
                     ->useRootNamespace($directory['namespace'] ?? app()->getNamespace())
-                    ->useBasePath($directory['base_path'] ?? isset($directory['namespace']) ? $namespace : app()->basePath())
+                    ->useBasePath($directory['base_path'] ?? (isset($directory['namespace']) ? $namespace : app()->basePath()))
                     ->group($options, fn () => $routeRegistrar->registerDirectory($namespace));
             } else {
                 is_string($namespace)

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -49,7 +49,7 @@ class RouteRegistrar
 
     public function useRootNamespace(string $rootNamespace): self
     {
-        $this->rootNamespace = rtrim($rootNamespace, '\\') . '\\';
+        $this->rootNamespace = rtrim(str_replace('/', '\\', $rootNamespace), '\\') . '\\';
 
         return $this;
     }

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -30,7 +30,7 @@ class RouteRegistrar
     {
         $this->router = $router;
 
-        $this->basePath = app()->path();
+        $this->useBasePath(app()->path());
     }
 
     public function group(array $options, $routes): self
@@ -42,7 +42,7 @@ class RouteRegistrar
 
     public function useBasePath(string $basePath): self
     {
-        $this->basePath = $basePath;
+        $this->basePath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $basePath);
 
         return $this;
     }

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -33,6 +33,13 @@ class RouteRegistrar
         $this->basePath = app()->path();
     }
 
+    public function group(array $options, $routes): self
+    {
+        $this->router->group($options, $routes);
+
+        return $this;
+    }
+
     public function useBasePath(string $basePath): self
     {
         $this->basePath = $basePath;
@@ -42,7 +49,7 @@ class RouteRegistrar
 
     public function useRootNamespace(string $rootNamespace): self
     {
-        $this->rootNamespace = $rootNamespace;
+        $this->rootNamespace = rtrim($rootNamespace, '\\') . '\\';
 
         return $this;
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -61,6 +61,5 @@ class ServiceProviderTest extends TestCase
             uri: 'grouped/my-post-method',
             middleware: ['SomeMiddleware', 'api']
         );
-
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests;
+
+use Spatie\RouteAttributes\RouteAttributesServiceProvider;
+use Spatie\RouteAttributes\RouteRegistrar;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Grouped\GroupTestController;
+
+class ServiceProviderTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->routeRegistrar = app(RouteRegistrar::class);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            RouteAttributesServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Resolve application core configuration implementation.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return void
+     */
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']->set('route-attributes.middleware', ['SomeMiddleware']);
+        $app['config']->set('route-attributes.directories', [
+            __DIR__ . '/TestClasses/Controllers/Grouped' => [
+                'prefix' => 'grouped',
+                'middleware' => 'api',
+                'namespace' => 'Spatie\RouteAttributes\Tests\TestClasses\Controllers\Grouped',
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function the_provider_can_register_group_of_directories()
+    {
+        $this->assertRegisteredRoutesCount(2);
+
+        $this->assertRouteRegistered(
+            GroupTestController::class,
+            controllerMethod: 'myGetMethod',
+            uri: 'grouped/my-get-method',
+            middleware: ['SomeMiddleware', 'api', 'test']
+        );
+
+        $this->assertRouteRegistered(
+            GroupTestController::class,
+            controllerMethod: 'myPostMethod',
+            httpMethods: 'post',
+            uri: 'grouped/my-post-method',
+            middleware: ['SomeMiddleware', 'api']
+        );
+
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Arr;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Spatie\RouteAttributes\RouteAttributesServiceProvider;
 use Spatie\RouteAttributes\RouteRegistrar;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
 
@@ -24,13 +23,6 @@ class TestCase extends Orchestra
             ->useBasePath($this->getTestPath())
             ->useMiddleware([AnotherTestMiddleware::class])
             ->useRootNamespace('Spatie\RouteAttributes\Tests\\');
-    }
-
-    protected function getPackageProviders($app)
-    {
-        return [
-            RouteAttributesServiceProvider::class,
-        ];
     }
 
     public function getTestPath(string $directory = null): string

--- a/tests/TestClasses/Controllers/Grouped/GroupTestController.php
+++ b/tests/TestClasses/Controllers/Grouped/GroupTestController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Grouped;
+
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Post;
+
+class GroupTestController
+{
+    #[Get('my-get-method', middleware: ['test'])]
+    public function myGetMethod()
+    {
+    }
+
+    #[Post('my-post-method')]
+    public function myPostMethod()
+    {
+    }
+}


### PR DESCRIPTION
This PR adds the possibility to give group options by directory in the config, instead of having to add the group options at the top of each class

I had to refactor slighlty the TestCaseas I noticed that the ServiceProvider was instantiated in every test case but with the wrong config and not loading any route, and the tests were not using it at all

Now it is only instanced within the ServiceProviderTest with a set of configurable options