### PR TITLE
Fix automated tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --ignore-platform-reqs
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit


### PR DESCRIPTION
Remove --ignore-platform-reqs from composer as this will cause dependencies with invalid php range to be installed (Eg: symfony/finder 6.1 on php8.0 which is only compatible with php8.1)