### PR TITLE
Implemented scoped bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,34 @@ register the route as follows;
 Route::get('my-get-route', [MyController::class, 'myGetMethod'])->domain('example.com');
 ```
 
+### Scoping bindings
+When implicitly binding multiple Eloquent models in a single route definition, you may wish to scope the second Eloquent model such that it must be a child of the previous Eloquent model.  
+By adding the `ScopeBindings` annotation, you can enable this behaviour:
+
+````php
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\ScopeBindings;
+
+class MyController
+{
+    #[Get('users/{user}/posts/{post}')]
+    #[ScopeBindings]
+    public function getUserPost(User $user, Post $post)
+    {
+        return $post;
+    }
+}
+````
+
+This is akin to using the `->scopeBindings()` method on the route registrar manually:
+```php
+Route::get('/users/{user}/posts/{post}', function (User $user, Post $post) {
+    return $post;
+})->scopeBindings();
+```
+
+You can also use the annotation on controllers to enable implicitly scoped bindings for all its methods.
+
 ### Specifying wheres
 
 You can use the `Where` annotation on a class or method to constrain the format of your route parameters.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.67|^9.0"
+        "illuminate/contracts": "^8.70|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0|^7.0",

--- a/src/Attributes/ScopeBindings.php
+++ b/src/Attributes/ScopeBindings.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
+class ScopeBindings implements RouteAttribute
+{
+    public function __construct(
+        public bool $scopeBindings = true
+    ) {
+    }
+}

--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -10,6 +10,7 @@ use Spatie\RouteAttributes\Attributes\Middleware;
 use Spatie\RouteAttributes\Attributes\Prefix;
 use Spatie\RouteAttributes\Attributes\Resource;
 use Spatie\RouteAttributes\Attributes\RouteAttribute;
+use Spatie\RouteAttributes\Attributes\ScopeBindings;
 use Spatie\RouteAttributes\Attributes\Where;
 
 class ClassRouteAttributes
@@ -165,6 +166,16 @@ class ClassRouteAttributes
         }
 
         return $attribute->middleware;
+    }
+
+    public function scopeBindings(): bool
+    {
+        /** @var \Spatie\RouteAttributes\Attributes\ScopeBindings $attribute */
+        if (! $attribute = $this->getAttribute(ScopeBindings::class)) {
+            return false;
+        }
+
+        return $attribute->scopeBindings;
     }
 
     /**

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -159,8 +159,10 @@ class RouteRegistrar
             $attributes = $method->getAttributes(RouteAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
             $wheresAttributes = $method->getAttributes(WhereAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
             $fallbackAttributes = $method->getAttributes(Fallback::class, ReflectionAttribute::IS_INSTANCEOF);
-            $scopeBindingsAttribute = $method->getAttributes(ScopeBindings::class,
-                ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
+            $scopeBindingsAttribute = $method->getAttributes(
+                ScopeBindings::class,
+                ReflectionAttribute::IS_INSTANCEOF
+            )[0] ?? null;
 
             foreach ($attributes as $attribute) {
                 try {
@@ -189,7 +191,7 @@ class RouteRegistrar
                     if ($scopeBindingsAttributeClass->scopeBindings) {
                         $route->scopeBindings();
                     }
-                } elseif($classRouteAttributes->scopeBindings()){
+                } elseif ($classRouteAttributes->scopeBindings()) {
                     $route->scopeBindings();
                 }
 

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -10,6 +10,7 @@ use ReflectionClass;
 use Spatie\RouteAttributes\Attributes\Fallback;
 use Spatie\RouteAttributes\Attributes\Route;
 use Spatie\RouteAttributes\Attributes\RouteAttribute;
+use Spatie\RouteAttributes\Attributes\ScopeBindings;
 use Spatie\RouteAttributes\Attributes\Where;
 use Spatie\RouteAttributes\Attributes\WhereAttribute;
 use SplFileInfo;
@@ -158,6 +159,8 @@ class RouteRegistrar
             $attributes = $method->getAttributes(RouteAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
             $wheresAttributes = $method->getAttributes(WhereAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
             $fallbackAttributes = $method->getAttributes(Fallback::class, ReflectionAttribute::IS_INSTANCEOF);
+            $scopeBindingsAttribute = $method->getAttributes(ScopeBindings::class,
+                ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
 
             foreach ($attributes as $attribute) {
                 try {
@@ -178,6 +181,17 @@ class RouteRegistrar
 
                 $route = $this->router->addRoute($httpMethods, $attributeClass->uri, $action)
                     ->name($attributeClass->name);
+
+                if ($scopeBindingsAttribute) {
+                    /** @var ScopeBindings $scopeBindingsAttributeClass */
+                    $scopeBindingsAttributeClass = $scopeBindingsAttribute->newInstance();
+
+                    if ($scopeBindingsAttributeClass->scopeBindings) {
+                        $route->scopeBindings();
+                    }
+                } elseif($classRouteAttributes->scopeBindings()){
+                    $route->scopeBindings();
+                }
 
                 $wheres = $classRouteAttributes->wheres();
                 foreach ($wheresAttributes as $wheresAttribute) {

--- a/tests/AttributeTests/ScopeBindingsAttributeTest.php
+++ b/tests/AttributeTests/ScopeBindingsAttributeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\AttributeTests;
+
+use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\BindingScoping1TestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\BindingScoping2TestController;
+
+class ScopeBindingsAttributeTest extends TestCase
+{
+    /** @test */
+    public function it_can_enable_binding_scoping_on_each_method_of_a_controller()
+    {
+        $this->routeRegistrar->registerClass(BindingScoping2TestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(
+                BindingScoping2TestController::class,
+                controllerMethod: 'explicitlyEnabledScopedBinding',
+                uri: 'explicitly-enabled/{scoped}/{binding}',
+                enforcesScopedBindings: true
+            )
+            ->assertRouteRegistered(
+                BindingScoping2TestController::class,
+                controllerMethod: 'implicitlyDisabledScopedBinding',
+                uri: 'implicitly-disabled/{scoped}/{binding}',
+                enforcesScopedBindings: false
+            );
+    }
+
+    /** @test */
+    public function it_can_enable_binding_scoping_on_individual_methods_of_a_controller()
+    {
+        $this->routeRegistrar->registerClass(BindingScoping1TestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(
+                BindingScoping1TestController::class,
+                controllerMethod: 'implicitlyEnabledScopedBinding',
+                uri: 'implicit/{scoped}/{binding}',
+                enforcesScopedBindings: true
+            )
+            ->assertRouteRegistered(
+                BindingScoping1TestController::class,
+                controllerMethod: 'explicitlyDisabledScopedBinding',
+                uri: 'explicitly-disabled/{scoped}/{binding}',
+                enforcesScopedBindings: false
+            );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,14 +48,15 @@ class TestCase extends Orchestra
         ?string $name = null,
         ?string $domain = null,
         ?array $wheres = [],
-        ?bool $isFallback = false
+        ?bool $isFallback = false,
+        ?bool $enforcesScopedBindings = false
     ): self {
         if (! is_array($middleware)) {
             $middleware = Arr::wrap($middleware);
         }
 
         $routeRegistered = collect($this->getRouteCollection()->getRoutes())
-            ->contains(function (Route $route) use ($name, $middleware, $controllerMethod, $controller, $uri, $httpMethods, $domain, $wheres, $isFallback) {
+            ->contains(function (Route $route) use ($name, $middleware, $controllerMethod, $controller, $uri, $httpMethods, $domain, $wheres, $isFallback, $enforcesScopedBindings) {
                 foreach (Arr::wrap($httpMethods) as $httpMethod) {
                     if (! in_array(strtoupper($httpMethod), $route->methods)) {
                         return false;
@@ -93,6 +94,10 @@ class TestCase extends Orchestra
                 }
 
                 if ($route->isFallback !== $isFallback) {
+                    return false;
+                }
+
+                if ($route->enforcesScopedBindings() !== $enforcesScopedBindings) {
                     return false;
                 }
 

--- a/tests/TestClasses/Controllers/BindingScoping1TestController.php
+++ b/tests/TestClasses/Controllers/BindingScoping1TestController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Route;
+use Spatie\RouteAttributes\Attributes\ScopeBindings;
+
+#[ScopeBindings]
+class BindingScoping1TestController
+{
+    #[Route('get', 'implicit/{scoped}/{binding}')]
+    public function implicitlyEnabledScopedBinding()
+    {
+    }
+
+    #[Route('get', 'explicitly-disabled/{scoped}/{binding}')]
+    #[ScopeBindings(scopeBindings: false)]
+    public function explicitlyDisabledScopedBinding()
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/BindingScoping2TestController.php
+++ b/tests/TestClasses/Controllers/BindingScoping2TestController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Route;
+use Spatie\RouteAttributes\Attributes\ScopeBindings;
+
+class BindingScoping2TestController
+{
+    #[Route('get', 'explicitly-enabled/{scoped}/{binding}')]
+    #[ScopeBindings]
+    public function explicitlyEnabledScopedBinding()
+    {
+    }
+
+    #[Route('get', 'implicitly-disabled/{scoped}/{binding}')]
+    public function implicitlyDisabledScopedBinding()
+    {
+    }
+}


### PR DESCRIPTION
This PR adds support for [scoped bindings](https://laravel.com/docs/9.x/routing#implicit-model-binding-scoping). It adds a new `ScopeBindings` attribute which may be used on controllers or controller methods.

### Usage
Following the Laravel documentation, the following example...
```php
Route::get('/users/{user}/posts/{post}', function (User $user, Post $post) {
    return $post;
})->scopeBindings();
```

...can now be implemented using route attributes as well:
```php
class PostsController
{
    #[Get('/users/{user}/posts/{post}')]
    #[ScopeBindings]
    public function getUserPost(User $user, Post $post)
    {
        return $post;
    }
}
```

### Grouped routes
As the attribute may be used on controllers, this also covers the grouped example case:
```php
Route::scopeBindings()->group(function () {
    Route::get('/users/{user}/posts/{post}', function (User $user, Post $post) {
        return $post;
    });
});
```

becomes:
```php
#[ScopeBindings]
class PostsController
{
    #[Get('/users/{user}/posts/{post}')]
    public function getUserPost(User $user, Post $post)
    {
        return $post;
    }
}
```