### PR TITLE
Patch handling of multiple directories in config (nested)

### DIFF
--- a/config/route-attributes.php
+++ b/config/route-attributes.php
@@ -11,6 +11,12 @@ return [
      * will automatically be registered.
      *
      * Optionally, you can specify group configuration by using key/values
+     *
+     * Files in  the added directories will only be processed once.
+     * When adding global directories (i.e. Http/Controllers) and Controller directories that are placed within
+     * the global directory  (i.e. Http/Controllers/Api) with extra prefix &| middleware make sure to place the
+     * more specific directory after the global directory (like seen in section install in readme)
+     *
      */
     'directories' => [
         app_path('Http/Controllers'),

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -22,7 +22,7 @@ class RouteAttributesServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/route-attributes.php', 'route-attributes');
 
-        $this->app->bind(RouteRegistrar::class,fn()=> new RouteRegistrar($this->app->router));
+        $this->app->bind(RouteRegistrar::class,fn()=> new RouteRegistrar(app()->router));
     }
 
     protected function registerRoutes(): void

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -21,6 +21,8 @@ class RouteAttributesServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/route-attributes.php', 'route-attributes');
+
+        $this->app->bind(RouteRegistrar::class,fn()=> new RouteRegistrar($this->app->router));
     }
 
     protected function registerRoutes(): void
@@ -29,7 +31,7 @@ class RouteAttributesServiceProvider extends ServiceProvider
             return;
         }
 
-        $routeRegistrar = (new RouteRegistrar(app()->router))
+        $routeRegistrar = app(RouteRegistrar::class)
             ->useMiddleware(config('route-attributes.middleware') ?? []);
 
         collect($this->getRouteDirectories())->each(function (string|array $directory, string|int $namespace) use ($routeRegistrar) {
@@ -54,7 +56,7 @@ class RouteAttributesServiceProvider extends ServiceProvider
         });
     }
 
-    private function shouldRegisterRoutes(): bool
+    protected function shouldRegisterRoutes(): bool
     {
         if (! config('route-attributes.enabled')) {
             return false;
@@ -67,8 +69,8 @@ class RouteAttributesServiceProvider extends ServiceProvider
         return true;
     }
 
-    private function getRouteDirectories(): array
+    protected function getRouteDirectories(): array
     {
-        return config('route-attributes.directories');
+        return array_reverse(config('route-attributes.directories'));
     }
 }

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -70,7 +70,7 @@ class RouteRegistrar
         return $this->middleware ?? [];
     }
 
-    public function registerDirectory(string | array $directories): void
+    public function registerDirectory(string | array $directory): void
     {
         $directory = Arr::wrap($directory);
 

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -19,6 +19,9 @@ use Throwable;
 
 class RouteRegistrar
 {
+
+    protected array $processedFiles = [];
+
     private Router $router;
 
     protected string $basePath;
@@ -69,11 +72,14 @@ class RouteRegistrar
 
     public function registerDirectory(string | array $directories): void
     {
-        $directories = Arr::wrap($directories);
+        $directory = Arr::wrap($directory);
 
-        $files = (new Finder())->files()->name('*.php')->in($directories)->sortByName();
+        $files = (new Finder())->files()->name('*.php')->in($directory)->sortByName();
 
-        collect($files)->each(fn (SplFileInfo $file) => $this->registerFile($file));
+        $files = collect($files)->filter(fn ($value, $key) => !in_array($key, $this->processedFiles));
+        $files->each(fn ($value, $key) => $this->processedFiles[] = $key);
+
+        $files->each(fn (\SplFileInfo $file) => $this->registerFile($file));
     }
 
     public function registerFile(string | SplFileInfo $path): void

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -6,7 +6,11 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\Registra
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\RegistrarTestSecondController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\RouteRegistrar\SubDirectory\RegistrarTestControllerInSubDirectory;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
+use ThirdParty\Http\Controllers\Api\AnApiController;
+use ThirdParty\Http\Controllers\Api\AnotherApiController;
 use ThirdParty\Http\Controllers\ThirdPartyController;
+use ThirdParty\Http\Controllers\View\AViewController;
+use const DIRECTORY_SEPARATOR;
 
 class RouteRegistrarTest extends TestCase
 {
@@ -79,6 +83,36 @@ class RouteRegistrarTest extends TestCase
         $this->assertRouteRegistered(
             ThirdPartyController::class,
             uri: 'third-party',
+            controllerMethod: 'thirdPartyGetMethod',
+        );
+    }
+
+    /** @test */
+    public function the_registrar_will_handle_nested_directories_correctly() :void
+    {
+
+        require_once(__DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api/AnApiController.php');
+        require_once(__DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api/AnotherApiController.php');
+        require_once(__DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/View/AViewController.php');
+        $this->routeRegistrar
+            ->useBasePath($this->getTestPath('ThirdPartyTestClasses' . DIRECTORY_SEPARATOR . 'MultipleDirectoriesControllerDirectory' . DIRECTORY_SEPARATOR . 'Controllers'))
+            ->useRootNamespace('ThirdParty\Http\Controllers\\')
+            ->registerDirectory($this->getTestPath('ThirdPartyTestClasses' . DIRECTORY_SEPARATOR . 'MultipleDirectoriesControllerDirectory' . DIRECTORY_SEPARATOR . 'Controllers'));
+
+        $this->assertRegisteredRoutesCount(3);
+        $this->assertRouteRegistered(
+            AnApiController::class,
+            uri: 'somewhere',
+            controllerMethod: 'thirdPartyGetMethod',
+        );
+        $this->assertRouteRegistered(
+            AnotherApiController::class,
+            uri: 'somewhen',
+            controllerMethod: 'thirdPartyGetMethod',
+        );
+        $this->assertRouteRegistered(
+            AViewController::class,
+            uri: 'somehow',
             controllerMethod: 'thirdPartyGetMethod',
         );
     }

--- a/tests/ServiceProviderWithMultipleDirectoriesInConfigTest.php
+++ b/tests/ServiceProviderWithMultipleDirectoriesInConfigTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests;
+
+use Spatie\RouteAttributes\RouteAttributesServiceProvider;
+use Spatie\RouteAttributes\RouteRegistrar;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Grouped\GroupTestController;
+use ThirdParty\Http\Controllers\Api\AnApiController;
+use ThirdParty\Http\Controllers\Api\AnotherApiController;
+use ThirdParty\Http\Controllers\View\AViewController;
+use const DIRECTORY_SEPARATOR;
+
+class ServiceProviderWithMultipleDirectoriesInConfigTest extends TestCase
+{
+
+    protected array $directoryConfig = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        require_once __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api/AnApiController.php';
+        require_once __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api/AnotherApiController.php';
+        require_once __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/View/AViewController.php';
+    }
+
+    public function setUp(): void
+    {
+    }
+
+    /** @test
+     * @dataProvider configServiceProvider
+     */
+    public function the_provider_will_not_register_routes_multiple_times(array $config, array $expectedRoutes, int $expectedRouteCount): void
+    {
+
+        $this->directoryConfig = $config;
+        $this->setUpTheTestEnvironment();
+        $this->app->bind(RouteRegistrar::class, function ($app) {
+            $registrar = new RouteRegistrar($app->router);
+            $registrar->useBasePath($this->getTestPath('ThirdPartyTestClasses' . DIRECTORY_SEPARATOR . 'MultipleDirectoriesControllerDirectory' . DIRECTORY_SEPARATOR . 'Controllers'))
+                ->useRootNamespace('ThirdParty\Http\Controllers\\')
+                ->registerDirectory($this->getTestPath('ThirdPartyTestClasses' . DIRECTORY_SEPARATOR . 'MultipleDirectoriesControllerDirectory' . DIRECTORY_SEPARATOR . 'Controllers'));
+            return $registrar;
+        });
+        $this->routeRegistrar = app(RouteRegistrar::class);
+        $this->assertRegisteredRoutesCount($expectedRouteCount);
+
+        foreach ($expectedRoutes as $registeredRoute) {
+            $this->assertRouteRegistered(...$registeredRoute);
+        }
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            RouteAttributesServiceProvider::class,
+        ];
+    }
+
+    protected function configServiceProvider(): array
+
+    {
+        return [
+            'config like in readme will resolve as expected' => [
+                'config' => [
+                    __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers',
+
+                    __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api' => [
+                        'middleware' => ['api'],
+                        'prefix' => 'api'
+                    ],
+                    __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/View' => [
+                        'middleware' => 'web'
+                    ],
+                ],
+                'expectedRoutes' => [
+                    [AViewController::class, 'thirdPartyGetMethod', 'get', 'somehow', ['SomeMiddleware', 'web']],
+                    [AnApiController::class, 'thirdPartyGetMethod', 'get', 'somewhere', ['SomeMiddleware', 'api']],
+                    [AnotherApiController::class, 'thirdPartyGetMethod', 'get', 'somewhen', ['SomeMiddleware', 'api']]
+                ],
+                'expectedRouteCount' => 3
+            ],
+            'changing the order will change the matching since global dir will resolve first' => [
+                'config' => [
+                    __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/View' => [
+                        'middleware' => 'web'
+                    ],
+                    __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api' => [
+                        'middleware' => ['api'],
+                        'prefix' => 'api'
+                    ],
+                    __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers',
+                ],
+                'expectedRoutes' => [
+                    [AViewController::class, 'thirdPartyGetMethod', 'get', 'somehow','SomeMiddleware'],
+                    [AnApiController::class, 'thirdPartyGetMethod', 'get', 'somewhere','SomeMiddleware'],
+                    [AnotherApiController::class, 'thirdPartyGetMethod', 'get', 'somewhen','SomeMiddleware']
+                ],
+                'expectedRouteCount' => 3
+            ],
+
+            'just passing the parent directory will still resolve all routes' => [
+                'config' => [
+                    __DIR__ . '/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers',
+                ],
+                'expectedRoutes' => [
+                    [AViewController::class, 'thirdPartyGetMethod', 'get', 'somehow', 'SomeMiddleware'],
+                    [AnApiController::class, 'thirdPartyGetMethod', 'get', 'somewhere', 'SomeMiddleware'],
+                    [AnotherApiController::class, 'thirdPartyGetMethod', 'get', 'somewhen', 'SomeMiddleware']
+                ],
+                'expectedRouteCount' => 3
+            ],
+
+        ];
+    }
+
+    /**
+     * Resolve application core configuration implementation.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     *
+     * @return void
+     */
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']->set('route-attributes.middleware', ['SomeMiddleware']);
+        $app['config']->set('route-attributes.directories', $this->directoryConfig);
+    }
+}

--- a/tests/ServiceProviderWithMultipleDirectoriesInConfigTest.php
+++ b/tests/ServiceProviderWithMultipleDirectoriesInConfigTest.php
@@ -34,7 +34,6 @@ class ServiceProviderWithMultipleDirectoriesInConfigTest extends TestCase
     {
 
         $this->directoryConfig = $config;
-        $this->setUpTheTestEnvironment();
         $this->app->bind(RouteRegistrar::class, function ($app) {
             $registrar = new RouteRegistrar($app->router);
             $registrar->useBasePath($this->getTestPath('ThirdPartyTestClasses' . DIRECTORY_SEPARATOR . 'MultipleDirectoriesControllerDirectory' . DIRECTORY_SEPARATOR . 'Controllers'))
@@ -43,18 +42,13 @@ class ServiceProviderWithMultipleDirectoriesInConfigTest extends TestCase
             return $registrar;
         });
         $this->routeRegistrar = app(RouteRegistrar::class);
+        $provider = new RouteAttributesServiceProvider(app());
+        $provider->boot();
         $this->assertRegisteredRoutesCount($expectedRouteCount);
 
         foreach ($expectedRoutes as $registeredRoute) {
             $this->assertRouteRegistered(...$registeredRoute);
         }
-    }
-
-    protected function getPackageProviders($app)
-    {
-        return [
-            RouteAttributesServiceProvider::class,
-        ];
     }
 
     protected function configServiceProvider(): array

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -104,7 +104,7 @@ class TestCase extends Orchestra
                 return true;
             });
 
-        $this->assertTrue($routeRegistered, 'The expected route was not registered');
+        $this->assertTrue($routeRegistered, 'The expected route with uri ' .$uri.' was not registered (?correctly)');
 
         return $this;
     }

--- a/tests/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api/AnApiController.php
+++ b/tests/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api/AnApiController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ThirdParty\Http\Controllers\Api;
+
+use Spatie\RouteAttributes\Attributes\Get;
+
+class AnApiController
+{
+    #[Get('somewhere')]
+    public function thirdPartyGetMethod()
+    {
+    }
+}

--- a/tests/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api/AnotherApiController.php
+++ b/tests/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/Api/AnotherApiController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ThirdParty\Http\Controllers\Api;
+
+use Spatie\RouteAttributes\Attributes\Get;
+
+class AnotherApiController
+{
+    #[Get('somewhen')]
+    public function thirdPartyGetMethod()
+    {
+    }
+}

--- a/tests/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/View/AViewController.php
+++ b/tests/ThirdPartyTestClasses/MultipleDirectoriesControllerDirectory/Controllers/View/AViewController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ThirdParty\Http\Controllers\View;
+
+use Spatie\RouteAttributes\Attributes\Get;
+
+class AViewController
+{
+    #[Get('somehow')]
+    public function thirdPartyGetMethod()
+    {
+    }
+}


### PR DESCRIPTION
### ISSUE


When using multiple Directories in the config (as seen in readme::installation) routes get registered multiple times.


i.e. having a Structure like this:

```
App\Http\Controllers\
    SomeController.php
    Api\
        AnotherController.php
```

and using a config like:

```
...
'directories' => [
        app_path('Http/Controllers'),
        app_path('Http/Controllers/API') => [
            'prefix' => 'api',
        ],
]
...
```

it will result in the routes of AnotherController to get registered twice. once without the path prefix, and one time with the correct prefix


### POC

sample from project i am currently working on

```
╰─❯ ./sail artisan route:list --name=location.getList                                                                                                                                                                                       

  GET|HEAD       api/locations .......................................................................................................................................... api.location.getList › API\Location\LocationApiController@locationsApi
  GET|HEAD       locations .............................................................................................................................................. api.location.getList › API\Location\LocationApiController@locationsApi

                                                                                                                                                                                                                              Showing [2] routes



PATCHED


╰─❯ ./sail artisan route:list --name=location.getList                              

  GET|HEAD       api/locations .......................................................................................................................................... api.location.getList › API\Location\LocationApiController@locationsApi

                                                                                                                                                                                                                              Showing [1] routes

```


config from sample

```
...
'directories' => [
        app_path('Http/Controllers'),
        app_path('Http/Controllers/API') => [
            'prefix' => 'api',
        ],
    ],
...
```

LocationsApiController has a route named "api.location.getList"


### Purpose

This pull request tries to resolve that issue ( also makes some private methods protected... since everyone should be able to extend a software easily, not by copy pasting i.e. the whole ServiceProvider :) )



TODO:
 - [ ] ServiceProviderWithMultipleDirectoriesInConfigTest should not fail assertions ( maybe i am missing something in the test setup ) 