### PR TITLE
Resource Attribute extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ To register a [resource controller](https://laravel.com/docs/controllers#resourc
 
 You can use `only` or `except` parameters to manage your resource routes availability (See [example 1](#resource-example-1) & [example 2](#resource-example-2)).
 
-You can use the `names` parameter to set the route names for the resource controller actions. Pass a string value to set a base route name for each controller action or pass an array value to define the route name for each controller action (See [example 1](#resource-example-1)).
-
 You can use `parameters` parameter to modify the default parameters set by the resource attribute (See [example 1](#resource-example-1)).
 
-Using `Resource` attribute with `Domain`, `Prefix` and `Middleware` attributes works as well (See [example 1](#resource-example-2)).
+Using `Resource` attribute with `Domain`, `Prefix` and `Middleware` attributes works as well (See [example 2](#resource-example-2)).
+
+You can use the `names` parameter to set the route names for the resource controller actions. Pass a string value to set a base route name for each controller action or pass an array value to define the route name for each controller action (See [example 2](#resource-example-2)).
 
 You can use `shallow` parameter to make a nested resource to apply nesting only to routes without a unique child identifier [`index`, `create`, `store`] (See [example 2](#resource-example-2)).
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can use the `names` parameter to set the route names for the resource contro
 
 You can use `shallow` parameter to make a nested resource to apply nesting only to routes without a unique child identifier (`index`, `create`, `store`).
 
-You can use `apiResource` parameter to only include actions used in APIs. Alternatively, you can use `ApiResource` attribute.
+You can use `apiResource` boolean parameter to only include actions used in APIs. Alternatively, you can use the `ApiResource` attribute, which extends the `Resource` attribute class, but the parameter `apiResource` is already set to `true`.
 
 Using `Resource` attribute with `Domain`, `Prefix` and `Middleware` attributes works as well.
 
@@ -162,6 +162,7 @@ use Spatie\RouteAttributes\Attributes\Resource;
     names: 'api.v1.photoComments',
     except: ['destroy'],
 )]
+// OR #[ApiResource(resource: 'photos.comments', shallow: true, ...)]
 class PhotoCommentController
 {   
     public function index(Photo $photo)

--- a/README.md
+++ b/README.md
@@ -136,69 +136,47 @@ We have left no HTTP verb behind. You can use these attributes on controller met
 
 ### Resource controllers
 
-To register a [resource controller](https://laravel.com/docs/controllers#resource-controllers), use the `Resource` attribute as shown in examples below.
+To register a [resource controller](https://laravel.com/docs/controllers#resource-controllers), use the `Resource` attribute as shown in the example below.
 
-You can use `only` or `except` parameters to manage your resource routes availability (See [example 1](#resource-example-1) & [example 2](#resource-example-2)).
+You can use `only` or `except` parameters to manage your resource routes availability.
 
-You can use `parameters` parameter to modify the default parameters set by the resource attribute (See [example 1](#resource-example-1)).
+You can use `parameters` parameter to modify the default parameters set by the resource attribute.
 
-Using `Resource` attribute with `Domain`, `Prefix` and `Middleware` attributes works as well (See [example 2](#resource-example-2)).
+You can use the `names` parameter to set the route names for the resource controller actions. Pass a string value to set a base route name for each controller action or pass an array value to define the route name for each controller action.
 
-You can use the `names` parameter to set the route names for the resource controller actions. Pass a string value to set a base route name for each controller action or pass an array value to define the route name for each controller action (See [example 2](#resource-example-2)).
+You can use `shallow` parameter to make a nested resource to apply nesting only to routes without a unique child identifier (`index`, `create`, `store`).
 
-You can use `shallow` parameter to make a nested resource to apply nesting only to routes without a unique child identifier [`index`, `create`, `store`] (See [example 2](#resource-example-2)).
+You can use `apiResource` parameter to only include actions used in APIs. Alternatively, you can use `ApiResource` attribute.
 
-You can use `apiResource` parameter to only include actions used in APIs. Alternatively, you can use `ApiResource` attribute (See [example 2](#resource-example-2)).
-
-#### Resource Example 1
+Using `Resource` attribute with `Domain`, `Prefix` and `Middleware` attributes works as well.
 
 ```php
 use Spatie\RouteAttributes\Attributes\Resource;
 
-#[Resource('posts', except: ['create', 'edit', 'destroy'], parameters: ['posts' => 'post_slug'])]
-class PostController
-{   
-    public function index()
-    {
-    }
-
-    public function store(Request $request)
-    {
-    }
-
-    public function show($post_slug)
-    {
-    }
-
-    public function update(Request $request, $post_slug)
-    {
-    }
-}
-```
-
-The attribute in the example above will automatically register following routes:
-
-```php
-Route::get('posts', [PhotoCommentController::class, 'index'])->name('posts.index');
-Route::post('posts', [PhotoCommentController::class, 'store'])->name('posts.show');
-Route::get('posts/{post_slug}', [PhotoCommentController::class, 'show'])->name('posts.show');
-Route::match(['put', 'patch'], 'posts/{post_slug}', [PhotoCommentController::class, 'update'])->name('posts.update');
-```
-
-#### Resource Example 2
-
-```php
-use Spatie\RouteAttributes\Attributes\ApiResource;
-
 #[Prefix('api/v1')]
-#[ApiResource('photos.comments', only: ['index', 'show'], shallow: true, names: 'api.v1.photoComments')]
+#[Resource(
+    resource: 'photos.comments', 
+    apiResource: true,
+    shallow: true, 
+    parameters: ['comments' => 'comment:uuid'],
+    names: 'api.v1.photoComments',
+    except: ['destroy'],
+)]
 class PhotoCommentController
 {   
-    public function index(Request $request, Photo $photo)
+    public function index(Photo $photo)
+    {
+    }
+
+    public function store(Request $request, Photo $photo)
     {
     }
 
     public function show(Comment $comment)
+    {
+    }
+
+    public function update(Request $request, Comment $comment)
     {
     }
 }
@@ -208,7 +186,9 @@ The attribute in the example above will automatically register following routes:
 
 ```php
 Route::get('api/v1/photos/{photo}/comments', [PhotoCommentController::class, 'index'])->name('api.v1.photoComments.index');
+Route::post('api/v1/photos/{photo}/comments', [PhotoCommentController::class, 'store'])->name('api.v1.photoComments.store');
 Route::get('api/v1/comments/{comment}', [PhotoCommentController::class, 'show'])->name('api.v1.photoComments.show');
+Route::match(['put', 'patch'], 'api/v1/comments/{comment}', [PhotoCommentController::class, 'update'])->name('api.v1.photoComments.update');
 ```
 
 ### Using multiple verbs

--- a/src/Attributes/ApiResource.php
+++ b/src/Attributes/ApiResource.php
@@ -5,16 +5,24 @@ namespace Spatie\RouteAttributes\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-class Resource implements RouteAttribute
+class ApiResource extends Resource
 {
     public function __construct(
         public string $resource,
-        public bool $apiResource = false,
         public array | string | null $except = null,
         public array | string | null $only = null,
         public array | string | null $names = null,
         public array | string | null $parameters = null,
         public bool | null $shallow = null,
     ) {
+        parent::__construct(
+            resource: $resource,
+            apiResource: true,
+            except: $except,
+            only: $only,
+            names: $names,
+            parameters: $parameters,
+            shallow: $shallow,
+        );
     }
 }

--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -104,6 +104,32 @@ class ClassRouteAttributes
     /**
      * @psalm-suppress NoInterfaceProperties
      */
+    public function parameters(): array | string | null
+    {
+        /** @var \Spatie\RouteAttributes\Attributes\Resource $attribute */
+        if (! $attribute = $this->getAttribute(Resource::class)) {
+            return null;
+        }
+
+        return $attribute->parameters;
+    }
+
+    /**
+     * @psalm-suppress NoInterfaceProperties
+     */
+    public function shallow(): bool | null
+    {
+        /** @var \Spatie\RouteAttributes\Attributes\Resource $attribute */
+        if (! $attribute = $this->getAttribute(Resource::class)) {
+            return null;
+        }
+
+        return $attribute->shallow;
+    }
+
+    /**
+     * @psalm-suppress NoInterfaceProperties
+     */
     public function apiResource(): ?string
     {
         /** @var \Spatie\RouteAttributes\Attributes\Resource $attribute */

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -149,6 +149,14 @@ class RouteRegistrar
                 $route->names($names);
             }
 
+            if ($parameters = $classRouteAttributes->parameters()) {
+                $route->parameters($parameters);
+            }
+
+            if (! is_null($shallow = $classRouteAttributes->shallow())) {
+                $route->shallow($shallow);
+            }
+
             $route->middleware([...$this->middleware, ...$classRouteAttributes->middleware()]);
         });
     }

--- a/tests/AttributeTests/ResourceAttributeTest.php
+++ b/tests/AttributeTests/ResourceAttributeTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
-use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\Resource1TestApiController;
-use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\Resource2TestApiController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ApiResource1TestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ApiResource2TestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestDomainController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestExceptController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestFullController;
@@ -284,7 +284,7 @@ class ResourceAttributeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_register_api_resource($controllerClass = Resource1TestApiController::class)
+    public function it_can_register_api_resource($controllerClass = ApiResource1TestController::class)
     {
         $this->routeRegistrar->registerClass($controllerClass);
 
@@ -328,7 +328,7 @@ class ResourceAttributeTest extends TestCase
     /** @test */
     public function it_can_register_api_resource_2()
     {
-        $this->it_can_register_api_resource(Resource2TestApiController::class);
+        $this->it_can_register_api_resource(ApiResource2TestController::class);
     }
 
     /** @test */

--- a/tests/AttributeTests/ResourceAttributeTest.php
+++ b/tests/AttributeTests/ResourceAttributeTest.php
@@ -3,7 +3,8 @@
 namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
-use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestApiController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\Resource1TestApiController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\Resource2TestApiController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestDomainController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestExceptController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestFullController;
@@ -11,7 +12,9 @@ use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestMi
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestNamesArrayController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestNamesStringController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestOnlyController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestParametersController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestPrefixController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource\ResourceTestShallowController;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\AnotherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\OtherTestMiddleware;
 use Spatie\RouteAttributes\Tests\TestClasses\Middleware\TestMiddleware;
@@ -281,43 +284,138 @@ class ResourceAttributeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_register_api_resource()
+    public function it_can_register_api_resource($controllerClass = Resource1TestApiController::class)
     {
-        $this->routeRegistrar->registerClass(ResourceTestApiController::class);
+        $this->routeRegistrar->registerClass($controllerClass);
 
         $this
             ->assertRegisteredRoutesCount(5)
             ->assertRouteRegistered(
-                ResourceTestApiController::class,
+                $controllerClass,
                 controllerMethod: 'index',
                 uri: 'posts',
                 name: 'posts.index'
             )
             ->assertRouteRegistered(
-                ResourceTestApiController::class,
+                $controllerClass,
                 controllerMethod: 'store',
                 httpMethods: 'post',
                 uri: 'posts',
                 name: 'posts.store'
             )
             ->assertRouteRegistered(
-                ResourceTestApiController::class,
+                $controllerClass,
                 controllerMethod: 'show',
                 uri: 'posts/{post}',
                 name: 'posts.show'
             )
             ->assertRouteRegistered(
-                ResourceTestApiController::class,
+                $controllerClass,
                 controllerMethod: 'update',
                 httpMethods: 'put',
                 uri: 'posts/{post}',
                 name: 'posts.update'
             )
             ->assertRouteRegistered(
-                ResourceTestApiController::class,
+                $controllerClass,
                 controllerMethod: 'destroy',
                 httpMethods: 'delete',
                 uri: 'posts/{post}',
+                name: 'posts.destroy'
+            );
+    }
+
+    /** @test */
+    public function it_can_register_api_resource_2()
+    {
+        $this->it_can_register_api_resource(Resource2TestApiController::class);
+    }
+
+    /** @test */
+    public function it_can_register_shallow_resource()
+    {
+        $this->routeRegistrar->registerClass(ResourceTestShallowController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(7)
+            ->assertRouteRegistered(
+                ResourceTestShallowController::class,
+                controllerMethod: 'index',
+                uri: 'users/{user}/posts',
+                name: 'users.posts.index'
+            )
+            ->assertRouteRegistered(
+                ResourceTestShallowController::class,
+                controllerMethod: 'create',
+                uri: 'users/{user}/posts/create',
+                name: 'users.posts.create'
+            )
+            ->assertRouteRegistered(
+                ResourceTestShallowController::class,
+                controllerMethod: 'store',
+                httpMethods: 'post',
+                uri: 'users/{user}/posts',
+                name: 'users.posts.store'
+            )
+            ->assertRouteRegistered(
+                ResourceTestShallowController::class,
+                controllerMethod: 'show',
+                uri: 'posts/{post}',
+                name: 'posts.show'
+            )
+            ->assertRouteRegistered(
+                ResourceTestShallowController::class,
+                controllerMethod: 'edit',
+                uri: 'posts/{post}/edit',
+                name: 'posts.edit'
+            )
+            ->assertRouteRegistered(
+                ResourceTestShallowController::class,
+                controllerMethod: 'update',
+                httpMethods: 'put',
+                uri: 'posts/{post}',
+                name: 'posts.update'
+            )
+            ->assertRouteRegistered(
+                ResourceTestShallowController::class,
+                controllerMethod: 'destroy',
+                httpMethods: 'delete',
+                uri: 'posts/{post}',
+                name: 'posts.destroy'
+            );
+    }
+
+    /** @test */
+    public function it_can_register_resource_with_modified_parameters()
+    {
+        $this->routeRegistrar->registerClass(ResourceTestParametersController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(7)
+            ->assertRouteRegistered(
+                ResourceTestParametersController::class,
+                controllerMethod: 'show',
+                uri: 'posts/{draft}',
+                name: 'posts.show'
+            )
+            ->assertRouteRegistered(
+                ResourceTestParametersController::class,
+                controllerMethod: 'edit',
+                uri: 'posts/{draft}/edit',
+                name: 'posts.edit'
+            )
+            ->assertRouteRegistered(
+                ResourceTestParametersController::class,
+                controllerMethod: 'update',
+                httpMethods: 'put',
+                uri: 'posts/{draft}',
+                name: 'posts.update'
+            )
+            ->assertRouteRegistered(
+                ResourceTestParametersController::class,
+                controllerMethod: 'destroy',
+                httpMethods: 'delete',
+                uri: 'posts/{draft}',
                 name: 'posts.destroy'
             );
     }

--- a/tests/AttributeTests/ResourceAttributeTest.php
+++ b/tests/AttributeTests/ResourceAttributeTest.php
@@ -284,40 +284,40 @@ class ResourceAttributeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_register_api_resource($controllerClass = ApiResource1TestController::class)
+    public function it_can_register_api_resource()
     {
-        $this->routeRegistrar->registerClass($controllerClass);
+        $this->routeRegistrar->registerClass(ApiResource1TestController::class);
 
         $this
             ->assertRegisteredRoutesCount(5)
             ->assertRouteRegistered(
-                $controllerClass,
+                ApiResource1TestController::class,
                 controllerMethod: 'index',
                 uri: 'posts',
                 name: 'posts.index'
             )
             ->assertRouteRegistered(
-                $controllerClass,
+                ApiResource1TestController::class,
                 controllerMethod: 'store',
                 httpMethods: 'post',
                 uri: 'posts',
                 name: 'posts.store'
             )
             ->assertRouteRegistered(
-                $controllerClass,
+                ApiResource1TestController::class,
                 controllerMethod: 'show',
                 uri: 'posts/{post}',
                 name: 'posts.show'
             )
             ->assertRouteRegistered(
-                $controllerClass,
+                ApiResource1TestController::class,
                 controllerMethod: 'update',
                 httpMethods: 'put',
                 uri: 'posts/{post}',
                 name: 'posts.update'
             )
             ->assertRouteRegistered(
-                $controllerClass,
+                ApiResource1TestController::class,
                 controllerMethod: 'destroy',
                 httpMethods: 'delete',
                 uri: 'posts/{post}',
@@ -328,7 +328,43 @@ class ResourceAttributeTest extends TestCase
     /** @test */
     public function it_can_register_api_resource_2()
     {
-        $this->it_can_register_api_resource(ApiResource2TestController::class);
+        $this->routeRegistrar->registerClass(ApiResource2TestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(5)
+            ->assertRouteRegistered(
+                ApiResource2TestController::class,
+                controllerMethod: 'index',
+                uri: 'posts',
+                name: 'posts.index'
+            )
+            ->assertRouteRegistered(
+                ApiResource2TestController::class,
+                controllerMethod: 'store',
+                httpMethods: 'post',
+                uri: 'posts',
+                name: 'posts.store'
+            )
+            ->assertRouteRegistered(
+                ApiResource2TestController::class,
+                controllerMethod: 'show',
+                uri: 'posts/{post}',
+                name: 'posts.show'
+            )
+            ->assertRouteRegistered(
+                ApiResource2TestController::class,
+                controllerMethod: 'update',
+                httpMethods: 'put',
+                uri: 'posts/{post}',
+                name: 'posts.update'
+            )
+            ->assertRouteRegistered(
+                ApiResource2TestController::class,
+                controllerMethod: 'destroy',
+                httpMethods: 'delete',
+                uri: 'posts/{post}',
+                name: 'posts.destroy'
+            );
     }
 
     /** @test */

--- a/tests/TestClasses/Controllers/Resource/ApiResource1TestController.php
+++ b/tests/TestClasses/Controllers/Resource/ApiResource1TestController.php
@@ -3,10 +3,10 @@
 namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource;
 
 use Illuminate\Http\Request;
-use Spatie\RouteAttributes\Attributes\ApiResource;
+use Spatie\RouteAttributes\Attributes\Resource;
 
-#[ApiResource('posts')]
-class Resource2TestApiController
+#[Resource('posts', apiResource: true)]
+class ApiResource1TestController
 {
     public function index()
     {

--- a/tests/TestClasses/Controllers/Resource/ApiResource2TestController.php
+++ b/tests/TestClasses/Controllers/Resource/ApiResource2TestController.php
@@ -3,10 +3,10 @@
 namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource;
 
 use Illuminate\Http\Request;
-use Spatie\RouteAttributes\Attributes\Resource;
+use Spatie\RouteAttributes\Attributes\ApiResource;
 
-#[Resource('posts', apiResource: true)]
-class Resource1TestApiController
+#[ApiResource('posts')]
+class ApiResource2TestController
 {
     public function index()
     {

--- a/tests/TestClasses/Controllers/Resource/Resource1TestApiController.php
+++ b/tests/TestClasses/Controllers/Resource/Resource1TestApiController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource;
+
+use Illuminate\Http\Request;
+use Spatie\RouteAttributes\Attributes\Resource;
+
+#[Resource('posts', apiResource: true)]
+class Resource1TestApiController
+{
+    public function index()
+    {
+    }
+
+    public function store(Request $request)
+    {
+    }
+
+    public function show($id)
+    {
+    }
+
+    public function update(Request $request, $id)
+    {
+    }
+
+    public function destroy($id)
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/Resource/Resource2TestApiController.php
+++ b/tests/TestClasses/Controllers/Resource/Resource2TestApiController.php
@@ -3,10 +3,10 @@
 namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource;
 
 use Illuminate\Http\Request;
-use Spatie\RouteAttributes\Attributes\Resource;
+use Spatie\RouteAttributes\Attributes\ApiResource;
 
-#[Resource('posts', apiResource: true)]
-class ResourceTestApiController
+#[ApiResource('posts')]
+class Resource2TestApiController
 {
     public function index()
     {

--- a/tests/TestClasses/Controllers/Resource/ResourceTestParametersController.php
+++ b/tests/TestClasses/Controllers/Resource/ResourceTestParametersController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource;
+
+use Illuminate\Http\Request;
+use Spatie\RouteAttributes\Attributes\Resource;
+
+#[Resource('posts', parameters: ['posts' => 'draft'])]
+class ResourceTestParametersController
+{
+    public function index()
+    {
+    }
+
+    public function create()
+    {
+    }
+
+    public function store(Request $request)
+    {
+    }
+
+    public function show($id)
+    {
+    }
+
+    public function edit($id)
+    {
+    }
+
+    public function update(Request $request, $id)
+    {
+    }
+
+    public function destroy($id)
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/Resource/ResourceTestShallowController.php
+++ b/tests/TestClasses/Controllers/Resource/ResourceTestShallowController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Resource;
+
+use Illuminate\Http\Request;
+use Spatie\RouteAttributes\Attributes\Resource;
+
+#[Resource('users.posts', shallow: true)]
+class ResourceTestShallowController
+{
+    public function index($userId)
+    {
+    }
+
+    public function create($userId)
+    {
+    }
+
+    public function store(Request $request, $userId)
+    {
+    }
+
+    public function show($id)
+    {
+    }
+
+    public function edit($id)
+    {
+    }
+
+    public function update(Request $request, $id)
+    {
+    }
+
+    public function destroy($id)
+    {
+    }
+}


### PR DESCRIPTION
This pull request adds the support for two additional properties in `Spatie\RouteAttributes\Attributes\Resource` attribute class:
- `array|string|null $parameters`
- `bool|null $shallow`

Additionally, ApiResource attribute class was added just to make the Attribute declarations shorter when using named arguments.
```php
// Before
#[Resource('posts', shallow: true, apiResource: true)]

// After
#[ApiResource('posts', shallow: true)]
```

Tests for all additions are included.