### PR TITLE
Add the ability to inherit attributes from parent

### DIFF
--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -82,18 +82,26 @@ class ClassRouteAttributes
                 ];
             }
         } elseif ($withDefault) {
-            $parentGroups = optional($this->parent())->groups(false);
-            if ($parentGroups !== null && count($parentGroups) > 0) {
-                $groups = $parentGroups;
-            } else {
-                $groups[] = [
-                    'domain' => $this->domainFromConfig() ?? $this->domain(),
-                    'prefix' => $this->prefix(),
-                ];
-            }
+            $groups = $this->groupsDefault();
         }
 
         return $groups;
+    }
+
+    /**
+     * @psalm-suppress NoInterfaceProperties
+     */
+    public function groupsDefault(): array
+    {
+        $parentGroups = optional($this->parent())->groups(false);
+        if ($parentGroups !== null && count($parentGroups) > 0) {
+            return $parentGroups;
+        }
+
+        return [[
+            'domain' => $this->domainFromConfig() ?? $this->domain(),
+            'prefix' => $this->prefix(),
+        ]];
     }
 
     /**

--- a/tests/AttributeTests/InheritAttributeTest.php
+++ b/tests/AttributeTests/InheritAttributeTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\AttributeTests;
+
+use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\InheritGroupOverrideTestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\InheritPrefixTestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\InheritGroupTestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\InheritPrefixOverrideTestController;
+
+class InheritAttributeTest extends TestCase
+{
+    /** @test */
+    public function it_can_apply_properties_from_parent_group()
+    {
+        $this->routeRegistrar->registerClass(InheritGroupTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(4)
+            ->assertRouteRegistered(
+                InheritGroupTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-prefix/my-get-method',
+                domain: 'my-subdomain.localhost'
+            )
+            ->assertRouteRegistered(
+                InheritGroupTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethods: 'post',
+                uri: 'my-prefix/my-post-method',
+                domain: 'my-subdomain.localhost'
+            )
+            ->assertRouteRegistered(
+                InheritGroupTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-second-prefix/my-get-method',
+                domain: 'my-second-subdomain.localhost'
+            )
+            ->assertRouteRegistered(
+                InheritGroupTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethods: 'post',
+                uri: 'my-second-prefix/my-post-method',
+                domain: 'my-second-subdomain.localhost'
+            );
+    }
+
+    /** @test */
+    public function it_can_override_parent_group()
+    {
+        $this->routeRegistrar->registerClass(InheritGroupOverrideTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(
+                InheritGroupOverrideTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'new-prefix/my-get-method',
+                domain: 'new-subdomain.localhost'
+            )
+            ->assertRouteRegistered(
+                InheritGroupOverrideTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethods: 'post',
+                uri: 'new-prefix/my-post-method',
+                domain: 'new-subdomain.localhost'
+            );
+    }
+
+    /** @test */
+    public function it_can_apply_properties_from_parent_prefix()
+    {
+        $this->routeRegistrar->registerClass(InheritPrefixTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(3)
+            ->assertRouteRegistered(
+                InheritPrefixTestController::class,
+                controllerMethod: 'myRootGetMethod',
+                uri: 'my-prefix',
+            )
+            ->assertRouteRegistered(
+                InheritPrefixTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-prefix/my-get-method',
+            )
+            ->assertRouteRegistered(
+                InheritPrefixTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethods: 'post',
+                uri: 'my-prefix/my-post-method',
+            );
+    }
+
+    /** @test */
+    public function it_can_override_parent_prefix()
+    {
+        $this->routeRegistrar->registerClass(InheritPrefixOverrideTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(3)
+            ->assertRouteRegistered(
+                InheritPrefixOverrideTestController::class,
+                controllerMethod: 'myRootGetMethod',
+                uri: 'new-prefix',
+            )
+            ->assertRouteRegistered(
+                InheritPrefixOverrideTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'new-prefix/my-get-method',
+            )
+            ->assertRouteRegistered(
+                InheritPrefixOverrideTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethods: 'post',
+                uri: 'new-prefix/my-post-method',
+            );
+    }
+}

--- a/tests/TestClasses/Controllers/InheritGroupOverrideTestController.php
+++ b/tests/TestClasses/Controllers/InheritGroupOverrideTestController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+use Spatie\RouteAttributes\Attributes\Group;
+
+#[Group(domain: 'new-subdomain.localhost', prefix: 'new-prefix')]
+class InheritGroupOverrideTestController extends GroupTestController
+{
+}

--- a/tests/TestClasses/Controllers/InheritGroupTestController.php
+++ b/tests/TestClasses/Controllers/InheritGroupTestController.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+class InheritGroupTestController extends GroupTestController
+{
+}

--- a/tests/TestClasses/Controllers/InheritPrefixOverrideTestController.php
+++ b/tests/TestClasses/Controllers/InheritPrefixOverrideTestController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+use Spatie\RouteAttributes\Attributes\Prefix;
+
+#[Prefix('new-prefix')]
+class InheritPrefixOverrideTestController extends PrefixTestController
+{
+}

--- a/tests/TestClasses/Controllers/InheritPrefixTestController.php
+++ b/tests/TestClasses/Controllers/InheritPrefixTestController.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+class InheritPrefixTestController extends PrefixTestController
+{
+}


### PR DESCRIPTION
This allows you to inherit `Group`, `Prefix`, or `Domain` from a parent-extended class:

```php
#[Prefix('my-prefix')]
class Controller
```

```php
class MyController extends Controller
```

==> `MyController` will have `my-prefix` as prefix.


If you override an attribute, it will be used instead of the parent one:
```php
#[Prefix('other-prefix')]
class OtherController extends Controller
```
==> `OtherController` will have `other-prefix` as prefix.
