### PR TITLE
Add defaults as attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,53 @@ Route::get('my-get-route', [MyController::class, 'myGetMethod'])->prefix('my-sec
 Route::post('my-post-route', [MyController::class, 'myPostMethod'])->prefix('my-second-prefix')->domain('my-second-subdomain.localhost');
 ```
 
+### Specifying defaults
+
+You can use the `Defaults` annotation on a class or method to define the default values of your optional route parameters.
+
+```php
+use Spatie\RouteAttributes\Attributes\Defaults;
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Post;
+
+#[Defaults('param', 'controller-default')]
+class MyController extends Controller
+{
+    #[Get('my-get-route/{param?}')]
+    public function myGetMethod($param)
+    {
+    }
+
+    #[Post('my-post-route/{param?}/{param2?}')]
+    #[Defaults('param2', 'method-default')]
+    public function myPostMethod($param, $param2)
+    {
+    }
+
+    #[Get('my-default-route/{param?}/{param2?}/{param3?}')]
+    #[Defaults('param2', 'method-default-first')]
+    #[Defaults('param3', 'method-default-second')]
+    public function myDefaultMethod($param, $param2, $param3)
+    {
+    }
+
+    #[Get('my-override-route/{param?}')]
+    #[Defaults('param', 'method-default')]
+    public function myOverrideMethod($param)
+    {
+    }
+}
+```
+
+These annotations will automatically register these routes:
+
+```php
+Route::get('my-get-route/{param?}', [MyController::class, 'myGetMethod'])->setDefaults(['param', 'controller-default']);
+Route::post('my-post-route/{param?}/{param2?}', [MyController::class, 'myPostMethod'])->setDefaults(['param', 'controller-default', 'param2' => 'method-default']);
+Route::get('my-default-route/{param?}/{param2?}/{param3?}', [MyController::class, 'myDefaultMethod'])->setDefaults(['param', 'controller-default', 'param2' => 'method-default-first', 'param3' => 'method-default-second']);
+Route::get('my-override-route/{param?}', [MyController::class, 'myOverrideMethod'])->setDefaults(['param', 'method-default']);
+```
+
 ## Testing
 
 ``` bash

--- a/src/Attributes/Defaults.php
+++ b/src/Attributes/Defaults.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\RouteAttributes\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class Defaults
+{
+    public function __construct(
+        public string $key,
+        public string $value,
+    ) {
+    }
+}

--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -3,6 +3,7 @@
 namespace Spatie\RouteAttributes;
 
 use ReflectionClass;
+use Spatie\RouteAttributes\Attributes\Defaults;
 use Spatie\RouteAttributes\Attributes\Domain;
 use Spatie\RouteAttributes\Attributes\DomainFromConfig;
 use Spatie\RouteAttributes\Attributes\Group;
@@ -216,6 +217,23 @@ class ClassRouteAttributes
         }
 
         return $wheres;
+    }
+
+    /**
+     * @psalm-suppress NoInterfaceProperties
+     */
+    public function defaults(): array
+    {
+        $defaults = [];
+        /** @var ReflectionClass[] $attributes */
+        $attributes = $this->class->getAttributes(Defaults::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+        foreach ($attributes as $attribute) {
+            $attributeClass = $attribute->newInstance();
+            $defaults[$attributeClass->key] = $attributeClass->value;
+        }
+
+        return $defaults;
     }
 
     protected function getAttribute(string $attributeClass): ?RouteAttribute

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -218,7 +218,6 @@ class RouteRegistrar
                 }
 
                 $defaults = $classRouteAttributes->defaults();
-
                 foreach ($defaultAttributes as $defaultAttribute) {
                     /** @var Defaults $default */
                     $defaultAttributeClass = $defaultAttribute->newInstance();
@@ -226,7 +225,6 @@ class RouteRegistrar
                     // This also overrides class defaults if the same default key is used
                     $defaults[$defaultAttributeClass->key] = $defaultAttributeClass->value;
                 }
-
                 if (! empty($defaults)) {
                     $route->setDefaults($defaults);
                 }

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionAttribute;
 use ReflectionClass;
+use Spatie\RouteAttributes\Attributes\Defaults;
 use Spatie\RouteAttributes\Attributes\Fallback;
 use Spatie\RouteAttributes\Attributes\Route;
 use Spatie\RouteAttributes\Attributes\RouteAttribute;
@@ -166,6 +167,7 @@ class RouteRegistrar
         foreach ($class->getMethods() as $method) {
             $attributes = $method->getAttributes(RouteAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
             $wheresAttributes = $method->getAttributes(WhereAttribute::class, ReflectionAttribute::IS_INSTANCEOF);
+            $defaultAttributes = $method->getAttributes(Defaults::class, ReflectionAttribute::IS_INSTANCEOF);
             $fallbackAttributes = $method->getAttributes(Fallback::class, ReflectionAttribute::IS_INSTANCEOF);
             $scopeBindingsAttribute = $method->getAttributes(
                 ScopeBindings::class,
@@ -213,6 +215,20 @@ class RouteRegistrar
                 }
                 if (! empty($wheres)) {
                     $route->setWheres($wheres);
+                }
+
+                $defaults = $classRouteAttributes->defaults();
+
+                foreach ($defaultAttributes as $defaultAttribute) {
+                    /** @var Defaults $default */
+                    $defaultAttributeClass = $defaultAttribute->newInstance();
+
+                    // This also overrides class defaults if the same default key is used
+                    $defaults[$defaultAttributeClass->key] = $defaultAttributeClass->value;
+                }
+
+                if (! empty($defaults)) {
+                    $route->setDefaults($defaults);
                 }
 
                 $classMiddleware = $classRouteAttributes->middleware();

--- a/tests/AttributeTests/DefaultAttributeTest.php
+++ b/tests/AttributeTests/DefaultAttributeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\AttributeTests;
+
+use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DefaultsTestController;
+
+class DefaultAttributeTest extends TestCase
+{
+    /** @test */
+    public function it_can_apply_defaults_on_each_method_of_a_controller()
+    {
+        $this->routeRegistrar->registerClass(DefaultsTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(4)
+            ->assertRouteRegistered(
+                DefaultsTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-get-method/{param?}',
+                defaults: ['param' => 'controller-default']
+            )->assertRouteRegistered(
+                DefaultsTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethods: 'post',
+                uri: 'my-post-method/{param?}/{param2?}',
+                defaults: ['param' => 'controller-default', 'param2' => 'method-default']
+            );
+    }
+
+    /** @test */
+    public function it_can_apply_more_than_one_defaults_on_a_method()
+    {
+        $this->routeRegistrar->registerClass(DefaultsTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(4)
+            ->assertRouteRegistered(
+                DefaultsTestController::class,
+                controllerMethod: 'myDefaultMethod',
+                uri: 'my-default-method/{param?}/{param2?}/{param3?}',
+                defaults: [
+                    'param' => 'controller-default',
+                    'param2' => 'method-default-first',
+                    'param3' => 'method-default-second'
+                ]
+            );
+    }
+
+    /** @test */
+    public function it_can_override_controller_defaults()
+    {
+        $this->routeRegistrar->registerClass(DefaultsTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(4)
+            ->assertRouteRegistered(
+                DefaultsTestController::class,
+                controllerMethod: 'myOverrideMethod',
+                uri: 'my-override-method/{param?}',
+                defaults: ['param' => 'method-default']
+            );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,14 +49,15 @@ class TestCase extends Orchestra
         ?string $domain = null,
         ?array $wheres = [],
         ?bool $isFallback = false,
-        ?bool $enforcesScopedBindings = false
+        ?bool $enforcesScopedBindings = false,
+        ?array $defaults = []
     ): self {
         if (! is_array($middleware)) {
             $middleware = Arr::wrap($middleware);
         }
 
         $routeRegistered = collect($this->getRouteCollection()->getRoutes())
-            ->contains(function (Route $route) use ($name, $middleware, $controllerMethod, $controller, $uri, $httpMethods, $domain, $wheres, $isFallback, $enforcesScopedBindings) {
+            ->contains(function (Route $route) use ($name, $middleware, $controllerMethod, $controller, $uri, $httpMethods, $domain, $wheres, $isFallback, $enforcesScopedBindings, $defaults) {
                 foreach (Arr::wrap($httpMethods) as $httpMethod) {
                     if (! in_array(strtoupper($httpMethod), $route->methods)) {
                         return false;
@@ -90,6 +91,10 @@ class TestCase extends Orchestra
                 }
 
                 if ($wheres !== $route->wheres) {
+                    return false;
+                }
+
+                if ($defaults !== $route->defaults) {
                     return false;
                 }
 

--- a/tests/TestClasses/Controllers/DefaultsTestController.php
+++ b/tests/TestClasses/Controllers/DefaultsTestController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Defaults;
+use Spatie\RouteAttributes\Attributes\Get;
+use Spatie\RouteAttributes\Attributes\Post;
+
+#[Defaults('param', 'controller-default')]
+class DefaultsTestController
+{
+    #[Get('my-get-method/{param?}')]
+    public function myGetMethod()
+    {
+    }
+
+    #[Post('my-post-method/{param?}/{param2?}')]
+    #[Defaults('param2', 'method-default')]
+    public function myPostMethod()
+    {
+    }
+
+    #[Get('my-default-method/{param?}/{param2?}/{param3?}')]
+    #[Defaults('param2', 'method-default-first')]
+    #[Defaults('param3', 'method-default-second')]
+    public function myDefaultMethod()
+    {
+    }
+
+    #[Get('my-override-method/{param?}')]
+    #[Defaults('param', 'method-default')]
+    public function myOverrideMethod()
+    {
+
+    }
+}


### PR DESCRIPTION
First of all, thanks for this great package and great idea to generate routes from controller attributes. 

This PR allows you to add a `Defaults` annotation on a class or method to define the default values of your optional route parameters:

```php
use Spatie\RouteAttributes\Attributes\Defaults;
use Spatie\RouteAttributes\Attributes\Get;
use Spatie\RouteAttributes\Attributes\Post;

#[Defaults('param', 'controller-default')]
class MyController extends Controller
{
    #[Get('my-get-route/{param?}')]
    public function myGetMethod($param)
    {
    }

    #[Post('my-post-route/{param?}/{param2?}')]
    #[Defaults('param2', 'method-default')]
    public function myPostMethod($param, $param2)
    {
    }

    #[Get('my-default-route/{param?}/{param2?}/{param3?}')]
    #[Defaults('param2', 'method-default-first')]
    #[Defaults('param3', 'method-default-second')]
    public function myDefaultMethod($param, $param2, $param3)
    {
    }

    #[Get('my-override-route/{param?}')]
    #[Defaults('param', 'method-default')]
    public function myOverrideMethod($param)
    {
    }
}
```

These annotations will automatically register these routes:

```php
Route::get('my-get-route/{param?}', [MyController::class, 'myGetMethod'])->setDefaults(['param', 'controller-default']);
Route::post('my-post-route/{param?}/{param2?}', [MyController::class, 'myPostMethod'])->setDefaults(['param', 'controller-default', 'param2' => 'method-default']);
Route::get('my-default-route/{param?}/{param2?}/{param3?}', [MyController::class, 'myDefaultMethod'])->setDefaults(['param', 'controller-default', 'param2' => 'method-default-first', 'param3' => 'method-default-second']);
Route::get('my-override-route/{param?}', [MyController::class, 'myOverrideMethod'])->setDefaults(['param', 'method-default']);
```

Let me know if you have any questions or suggestions.

Thanks!

