### PR TITLE
Add WhereUlid shorthand where

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ For convenience, some commonly used regular expression patterns have helper attr
 #[WhereAlpha('alpha')]
 #[WhereAlphaNumeric('alpha-numeric')]
 #[WhereNumber('number')]
+#[WhereUlid('ulid')]
 #[WhereUuid('uuid')]
 ```
 

--- a/src/Attributes/WhereUlid.php
+++ b/src/Attributes/WhereUlid.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\RouteAttributes\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class WhereUlid extends Where
+{
+    public function __construct(string $param)
+    {
+        $this->param = $param;
+        $this->constraint = '[0-7][0-9A-HJKMNP-TV-Z]{25}';
+    }
+}

--- a/tests/AttributeTests/WhereAttributeTest.php
+++ b/tests/AttributeTests/WhereAttributeTest.php
@@ -60,6 +60,7 @@ class WhereAttributeTest extends TestCase
                     'alpha' => '[a-zA-Z]+',
                     'alpha-numeric' => '[a-zA-Z0-9]+',
                     'number' => '[0-9]+',
+                    'ulid' => '[0-7][0-9A-HJKMNP-TV-Z]{25}',
                     'uuid' => '[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}',
                 ]
             );

--- a/tests/TestClasses/Controllers/WhereTestController.php
+++ b/tests/TestClasses/Controllers/WhereTestController.php
@@ -8,6 +8,7 @@ use Spatie\RouteAttributes\Attributes\Where;
 use Spatie\RouteAttributes\Attributes\WhereAlpha;
 use Spatie\RouteAttributes\Attributes\WhereAlphaNumeric;
 use Spatie\RouteAttributes\Attributes\WhereNumber;
+use Spatie\RouteAttributes\Attributes\WhereUlid;
 use Spatie\RouteAttributes\Attributes\WhereUuid;
 
 #[Where('param', '[0-9]+')]
@@ -35,6 +36,7 @@ class WhereTestController
     #[WhereAlpha('alpha')]
     #[WhereAlphaNumeric('alpha-numeric')]
     #[WhereNumber('number')]
+    #[WhereUlid('ulid')]
     #[WhereUuid('uuid')]
     public function myShorthands()
     {


### PR DESCRIPTION
This PR adds a new shorthand where attribute to handle ULIDs.

Support for ULIDs were introduced in Laravel 9.30.1 as an alternative for Eloquent models primary keys.



Notes:

- As per ULID spec:
  - all characters should be compatible with Crokford's base32 (digits and letters other than `I`, `L`, `O`, and `U`)
  - also, the largest ULID to be allowed is `7ZZZZZZZZZZZZZZZZZZZZZZZZZ` 
  - therefore, the first character must be in the range `[0-7]`
  - while all remaining 25 characters should be in range `[0-9A-HJKMNP-TV-Z]`
  - this justifies the regular expression used
- A relevant test case was adapted to check for this new attribute.

References:

- https://github.com/laravel/framework/blob/9.x/CHANGELOG.md#v9301---2022-09-15
- https://github.com/ulid/spec
- https://www.crockford.com/base32.html
