### PR TITLE
Add PHP 8.2 to tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - laravel: 9.*
             testbench: 7.*
-            phpunit: 9.4.*
+            phpunit: 9.5.*
           - laravel: 8.*
             testbench: 6.*
             phpunit: 9.4.*
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "phpunit/phpunit:${{ matrix.phpunit }}" "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --ignore-platform-req=php
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-req=php
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,9 +33,13 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
+      - name: Configure for PHP 8.2
+        run: composer config platform.php 8.1.99
+        if: matrix.php == '8.2'
+
       - name: Install dependencies
         run: |
-          composer require "phpunit/phpunit:${{ matrix.phpunit }}" "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --ignore-platform-req=php
+          composer require "phpunit/phpunit:${{ matrix.phpunit }}" "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,10 +15,10 @@ jobs:
         include:
           - laravel: 9.*
             testbench: 7.*
-            phpunit: 9.*
+            phpunit: 9.4.*
           - laravel: 8.*
             testbench: 6.*
-            phpunit: '^9.4'
+            phpunit: 9.4.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
             phpunit: 9.*
           - laravel: 8.*
             testbench: 6.*
-            phpunit: 9.4.4
+            phpunit: '^9.4'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -35,8 +35,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "phpunit/phpunit:${{ matrix.phpunit }}" "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          composer require "phpunit/phpunit:${{ matrix.phpunit }}" "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --ignore-platform-req=php
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-req=php
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 8.1]
+        php: [8.0, 8.1, 8.2]
         laravel: [9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
             phpunit: 9.*
           - laravel: 8.*
             testbench: 6.*
-            phpunit: 9.4.*
+            phpunit: 9.4.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,10 @@ jobs:
         include:
           - laravel: 9.*
             testbench: 7.*
+            phpunit: 9.*
           - laravel: 8.*
             testbench: 6.*
+            phpunit: 9.4.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -33,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "phpunit/phpunit:${{ matrix.phpunit }}" "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,11 @@
     "require": {
         "php": "^8.0",
         "illuminate/contracts": "^8.70|^9.0",
-        "laravel/framework": "8.*",
-        "nesbot/carbon": "^2.63",
-        "orchestra/testbench": "6.*",
-        "phpunit/phpunit": "9.4.*"
+        "nesbot/carbon": "^2.63"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^6.25|^7.0",
+        "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "nesbot/carbon": "^2.63"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0|^7.0",
-        "phpunit/phpunit": "^9.3"
+        "orchestra/testbench": "^6.13|^7.0",
+        "phpunit/phpunit": "^9.5.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.70|^9.0"
+        "illuminate/contracts": "^8.70|^9.0",
+        "nesbot/carbon": "^2.63"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^6.13|^7.0",
-        "phpunit/phpunit": "^9.5.2"
+        "phpunit/phpunit": "^9.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,10 @@
     "require": {
         "php": "^8.0",
         "illuminate/contracts": "^8.70|^9.0",
-        "nesbot/carbon": "^2.63"
-    },
-    "require-dev": {
-        "orchestra/testbench": "^6.13|^7.0",
-        "phpunit/phpunit": "^9.4"
+        "laravel/framework": "8.*",
+        "nesbot/carbon": "^2.63",
+        "orchestra/testbench": "6.*",
+        "phpunit/phpunit": "9.4.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds PHP 8.2 to the tests workflow and bumps the version of the `checkout` action to v3. It also bumps some minimum dependency versions and adds additional configuration to the tests workflow to allow PHP 8.2 support.