### PR TITLE
🐛 Should filter null values when resolving group

### DIFF
--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -72,18 +72,18 @@ class ClassRouteAttributes
         if (count($attributes) > 0) {
             foreach ($attributes as $attribute) {
                 $attributeClass = $attribute->newInstance();
-                $groups[] = [
+                $groups[] = array_filter([
                     'domain' => $attributeClass->domain,
                     'prefix' => $attributeClass->prefix,
                     'where' => $attributeClass->where,
                     'as' => $attributeClass->as,
-                ];
+                ]);
             }
         } else {
-            $groups[] = [
+            $groups[] = array_filter([
                 'domain' => $this->domainFromConfig() ?? $this->domain(),
                 'prefix' => $this->prefix(),
-            ];
+            ]);
         }
 
         return $groups;


### PR DESCRIPTION
Given the ff config:

```php
return [
    ...
    'directories' => [
        app_path('HttpApi/Controllers') => [
            'domain' => parse_url(env('APP_URL', ''), PHP_URL_HOST),
        ],
    ],
    ...
],
```

Prior to this PR, it tries to register the ff and causes an error:
```
"domain" => [
    'localhost',
    null,
]
```

The proposed solution filters null option in the group.