### PR TITLE
Add patterns and not_patterns options to directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ For controllers outside the applications root namespace directories can also be 
 ],
 ```
 
+If you are using a directory structure where you co-locate multiple types of files in the same directory and want to 
+be more specific about which files are checked for route attributes, you can use the `patterns` and `not_patterns` 
+options. For example, if you are co-locating your tests with your controllers you could use the `patterns` option to only 
+look in controller files, or you could use `not_patterns` to configure it to not look in test files for route 
+attributes.
+
+```php
+'directories' => [
+    base_path('app-modules/Blog') => [
+        // only register routes in files that match the patterns
+        'patterns' => ['*Controller.php'],
+        // do not register routes in files that match the patterns
+        'not_patterns => ['*Test.php'],
+    ],
+],
+```
+
 ## Usage
 
 The package provides several annotations that should be put on controller classes and methods. These annotations will be used to automatically register routes

--- a/config/route-attributes.php
+++ b/config/route-attributes.php
@@ -18,6 +18,10 @@ return [
         app_path('Http/Controllers/Api') => [
            'prefix' => 'api',
            'middleware' => 'api',
+            // only register routes in files that match the patterns
+           'patterns' => ['*Controller.php'],
+           // do not register routes in files that match the patterns
+           'not_patterns => [],
         ],
         */
     ],

--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -34,12 +34,12 @@ class RouteAttributesServiceProvider extends ServiceProvider
 
         collect($this->getRouteDirectories())->each(function (string|array $directory, string|int $namespace) use ($routeRegistrar) {
             if (is_array($directory)) {
-                $options = Arr::except($directory, ['namespace', 'base_path']);
+                $options = Arr::except($directory, ['namespace', 'base_path', 'patterns', 'not_patterns']);
 
                 $routeRegistrar
                     ->useRootNamespace($directory['namespace'] ?? app()->getNamespace())
                     ->useBasePath($directory['base_path'] ?? (isset($directory['namespace']) ? $namespace : app()->path()))
-                    ->group($options, fn () => $routeRegistrar->registerDirectory($namespace));
+                    ->group($options, fn () => $routeRegistrar->registerDirectory($namespace, $directory['patterns'] ?? [], $directory['not_patterns'] ?? []));
             } else {
                 is_string($namespace)
                     ? $routeRegistrar

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -67,11 +67,12 @@ class RouteRegistrar
         return $this->middleware ?? [];
     }
 
-    public function registerDirectory(string | array $directories): void
+    public function registerDirectory(string | array $directories, array $patterns = [], array $notPatterns = []): void
     {
         $directories = Arr::wrap($directories);
+        $patterns = $patterns ?: ['*.php'];
 
-        $files = (new Finder())->files()->name('*.php')->in($directories)->sortByName();
+        $files = (new Finder())->files()->in($directories)->name($patterns)->notName($notPatterns)->sortByName();
 
         collect($files)->each(fn (SplFileInfo $file) => $this->registerFile($file));
     }

--- a/tests/RouteRegistrarTest.php
+++ b/tests/RouteRegistrarTest.php
@@ -82,4 +82,29 @@ class RouteRegistrarTest extends TestCase
             controllerMethod: 'thirdPartyGetMethod',
         );
     }
+
+    /** @test */
+    public function the_registrar_can_register_a_directory_with_filename_pattern()
+    {
+        $this
+            ->routeRegistrar
+            ->registerDirectory($this->getTestPath('TestClasses/Controllers/RouteRegistrar'), ['*FirstController.php']);
+
+        $this->assertRegisteredRoutesCount(1);
+
+        $this->assertRouteRegistered(
+            RegistrarTestFirstController::class,
+            uri: 'first-method',
+        );
+    }
+
+    /** @test */
+    public function the_registrar_can_register_a_directory_with_filename_not_pattern()
+    {
+        $this
+            ->routeRegistrar
+            ->registerDirectory($this->getTestPath('TestClasses/Controllers/RouteRegistrar'), [], ['*FirstController.php']);
+
+        $this->assertRegisteredRoutesCount(2);
+    }
 }


### PR DESCRIPTION
I am using a modular directory structure where I co-locate my controllers, form requests, and even tests in the same directory. I ran into a problem when it was scanning files to look for route attributes it loaded one of my test files but since in production I run composer with `--no-dev` it did not have the `PHPUnit\Framework\TestCase` and I got a class not found error. I needed a way to be more specific with which files are checked for routes.

In your `config/route-attributes.php` file if you are using the array format then you can specify `patterns` and `not_patterns` for that directory.

```php
    'directories' => [
        app_path('Http/Controllers/Api') => [
           'prefix' => 'api',
           'middleware' => 'api',
            // only register routes in files that match the patterns
           'patterns' => ['*Controller.php'],
           // do not register routes in files that match the patterns
           'not_patterns => ['*Test.php'],
        ],
    ],
```

This also has performance benefits since it will only scan the files that match the patterns.
