### PR TITLE
Allow to register multiple Get route declarations on one method

### DIFF
--- a/src/Attributes/Delete.php
+++ b/src/Attributes/Delete.php
@@ -4,7 +4,7 @@ namespace Spatie\RouteAttributes\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Delete extends Route
 {
     public function __construct(

--- a/src/Attributes/Get.php
+++ b/src/Attributes/Get.php
@@ -4,7 +4,7 @@ namespace Spatie\RouteAttributes\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Get extends Route
 {
     public function __construct(

--- a/src/Attributes/Options.php
+++ b/src/Attributes/Options.php
@@ -4,7 +4,7 @@ namespace Spatie\RouteAttributes\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Options extends Route
 {
     public function __construct(

--- a/src/Attributes/Patch.php
+++ b/src/Attributes/Patch.php
@@ -4,7 +4,7 @@ namespace Spatie\RouteAttributes\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Patch extends Route
 {
     public function __construct(

--- a/src/Attributes/Post.php
+++ b/src/Attributes/Post.php
@@ -4,7 +4,7 @@ namespace Spatie\RouteAttributes\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Post extends Route
 {
     public function __construct(

--- a/src/Attributes/Put.php
+++ b/src/Attributes/Put.php
@@ -4,7 +4,7 @@ namespace Spatie\RouteAttributes\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Put extends Route
 {
     public function __construct(

--- a/tests/AttributeTests/DeleteAttributeTest.php
+++ b/tests/AttributeTests/DeleteAttributeTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DeleteMultipleTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\DeleteTestController;
 
 class DeleteAttributeTest extends TestCase
@@ -15,5 +16,16 @@ class DeleteAttributeTest extends TestCase
         $this
             ->assertRegisteredRoutesCount(1)
             ->assertRouteRegistered(DeleteTestController::class, 'myDeleteMethod', 'delete', 'my-delete-method');
+    }
+
+    /** @test */
+    public function it_can_register_multiple_delete_routes()
+    {
+        $this->routeRegistrar->registerClass(DeleteMultipleTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(DeleteMultipleTestController::class, 'myDeleteMethod', 'delete', 'my-delete-method')
+            ->assertRouteRegistered(DeleteMultipleTestController::class, 'myDeleteMethod', 'delete', 'my-other-delete-method');
     }
 }

--- a/tests/AttributeTests/GetAttributeTest.php
+++ b/tests/AttributeTests/GetAttributeTest.php
@@ -4,6 +4,7 @@ namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\GetTestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\GetMultipleTestController;
 
 class GetAttributeTest extends TestCase
 {
@@ -15,5 +16,16 @@ class GetAttributeTest extends TestCase
         $this
             ->assertRegisteredRoutesCount(1)
             ->assertRouteRegistered(GetTestController::class, 'myGetMethod', 'get', 'my-get-method');
+    }
+
+    /** @test */
+    public function it_can_register_multiple_get_routes()
+    {
+        $this->routeRegistrar->registerClass(GetMultipleTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(GetMultipleTestController::class, 'myGetMethod', 'get', 'my-get-method')
+            ->assertRouteRegistered(GetMultipleTestController::class, 'myGetMethod', 'get', 'my-other-get-method');;
     }
 }

--- a/tests/AttributeTests/OptionsAttributeTest.php
+++ b/tests/AttributeTests/OptionsAttributeTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\OptionsMultipleTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\OptionsTestController;
 
 class OptionsAttributeTest extends TestCase
@@ -15,5 +16,16 @@ class OptionsAttributeTest extends TestCase
         $this
             ->assertRegisteredRoutesCount(1)
             ->assertRouteRegistered(OptionsTestController::class, 'myOptionsMethod', 'options', 'my-options-method');
+    }
+
+    /** @test */
+    public function it_can_register_multiple_options_routes()
+    {
+        $this->routeRegistrar->registerClass(OptionsMultipleTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(OptionsMultipleTestController::class, 'myOptionsMethod', 'options', 'my-options-method')
+            ->assertRouteRegistered(OptionsMultipleTestController::class, 'myOptionsMethod', 'options', 'my-other-options-method');
     }
 }

--- a/tests/AttributeTests/PatchAttributeTest.php
+++ b/tests/AttributeTests/PatchAttributeTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PatchMultipleTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PatchTestController;
 
 class PatchAttributeTest extends TestCase
@@ -15,5 +16,16 @@ class PatchAttributeTest extends TestCase
         $this
             ->assertRegisteredRoutesCount(1)
             ->assertRouteRegistered(PatchTestController::class, 'myPatchMethod', 'patch', 'my-patch-method');
+    }
+
+    /** @test */
+    public function it_can_register_multiple_patch_routes()
+    {
+        $this->routeRegistrar->registerClass(PatchMultipleTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(PatchMultipleTestController::class, 'myPatchMethod', 'patch', 'my-patch-method')
+            ->assertRouteRegistered(PatchMultipleTestController::class, 'myPatchMethod', 'patch', 'my-other-patch-method');
     }
 }

--- a/tests/AttributeTests/PostAttributeTest.php
+++ b/tests/AttributeTests/PostAttributeTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PostMultipleTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PostTestController;
 
 class PostAttributeTest extends TestCase
@@ -15,5 +16,16 @@ class PostAttributeTest extends TestCase
         $this
             ->assertRegisteredRoutesCount(1)
             ->assertRouteRegistered(PostTestController::class, 'myPostMethod', 'post', 'my-post-method');
+    }
+
+    /** @test */
+    public function it_can_register_multiple_post_routes()
+    {
+        $this->routeRegistrar->registerClass(PostMultipleTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(PostMultipleTestController::class, 'myPostMethod', 'post', 'my-post-method')
+            ->assertRouteRegistered(PostMultipleTestController::class, 'myPostMethod', 'post', 'my-other-post-method');
     }
 }

--- a/tests/AttributeTests/PutAttributeTest.php
+++ b/tests/AttributeTests/PutAttributeTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\RouteAttributes\Tests\AttributeTests;
 
 use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PutMultipleTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\PutTestController;
 
 class PutAttributeTest extends TestCase
@@ -15,5 +16,16 @@ class PutAttributeTest extends TestCase
         $this
             ->assertRegisteredRoutesCount(1)
             ->assertRouteRegistered(PutTestController::class, 'myPutMethod', 'put', 'my-put-method');
+    }
+
+    /** @test */
+    public function it_can_register_multiple_put_routes()
+    {
+        $this->routeRegistrar->registerClass(PutMultipleTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(2)
+            ->assertRouteRegistered(PutMultipleTestController::class, 'myPutMethod', 'put', 'my-put-method')
+            ->assertRouteRegistered(PutMultipleTestController::class, 'myPutMethod', 'put', 'my-other-put-method');
     }
 }

--- a/tests/TestClasses/Controllers/DeleteMultipleTestController.php
+++ b/tests/TestClasses/Controllers/DeleteMultipleTestController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Delete;
+
+class DeleteMultipleTestController
+{
+    #[Delete('my-delete-method')]
+    #[Delete('my-other-delete-method')]
+    public function myDeleteMethod()
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/GetMultipleTestController.php
+++ b/tests/TestClasses/Controllers/GetMultipleTestController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Get;
+
+class GetMultipleTestController
+{
+    #[Get('my-get-method')]
+    #[Get('my-other-get-method')]
+    public function myGetMethod()
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/OptionsMultipleTestController.php
+++ b/tests/TestClasses/Controllers/OptionsMultipleTestController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Options;
+
+class OptionsMultipleTestController
+{
+    #[Options('my-options-method')]
+    #[Options('my-other-options-method')]
+    public function myOptionsMethod()
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/PatchMultipleTestController.php
+++ b/tests/TestClasses/Controllers/PatchMultipleTestController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Patch;
+
+class PatchMultipleTestController
+{
+    #[Patch('my-patch-method')]
+    #[Patch('my-other-patch-method')]
+    public function myPatchMethod()
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/PostMultipleTestController.php
+++ b/tests/TestClasses/Controllers/PostMultipleTestController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Post;
+
+class PostMultipleTestController
+{
+    #[Post('my-post-method')]
+    #[Post('my-other-post-method')]
+    public function myPostMethod()
+    {
+    }
+}

--- a/tests/TestClasses/Controllers/PutMultipleTestController.php
+++ b/tests/TestClasses/Controllers/PutMultipleTestController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Put;
+
+class PutMultipleTestController
+{
+    #[Put('my-put-method')]
+    #[Put('my-other-put-method')]
+    public function myPutMethod()
+    {
+    }
+}


### PR DESCRIPTION
Makes the `#[Get('')]` Attribute repeatable and therefore allows multiple `Get` route declarations to be added to a single method. Like this:

```
#[Get('my-get-method')]
#[Get('my-other-get-method')]
public function myMethod() {}
```

Im not sure what implications this might have, but it would definitely be handy from time to time - at least for me :-)

If you are interested, I could expand this PR to the other verbs / attributes.