### PR TITLE
Explicitly call `withoutScopedBindings` when attribute boolean is set to false

### DIFF
--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -193,11 +193,11 @@ class ClassRouteAttributes
         return $attribute->middleware;
     }
 
-    public function scopeBindings(): bool
+    public function scopeBindings(): ?bool
     {
         /** @var ScopeBindings $attribute */
         if (! $attribute = $this->getAttribute(ScopeBindings::class)) {
-            return false;
+            return null;
         }
 
         return $attribute->scopeBindings;

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -195,7 +195,7 @@ class RouteRegistrar
 
         if ($shouldScopeBindings) {
             $route->scopeBindings();
-        } else {
+        } elseif (method_exists($route, 'withoutScopedBindings')) {
             $route->withoutScopedBindings();
         }
     }

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -187,14 +187,16 @@ class RouteRegistrar
      */
     public function setScopeBindingsIfAvailable(?ReflectionAttribute $scopeBindingsAttribute, \Illuminate\Routing\Route $route, ClassRouteAttributes $classRouteAttributes): void
     {
-        if ($scopeBindingsAttribute) {
-            $scopeBindingsAttributeClass = $scopeBindingsAttribute->newInstance();
+        $shouldScopeBindings = $scopeBindingsAttribute?->newInstance()->scopeBindings ?? $classRouteAttributes->scopeBindings();
 
-            if ($scopeBindingsAttributeClass->scopeBindings) {
-                $route->scopeBindings();
-            }
-        } elseif ($classRouteAttributes->scopeBindings()) {
+        if ($shouldScopeBindings === null) {
+            return;
+        }
+
+        if ($shouldScopeBindings) {
             $route->scopeBindings();
+        } else {
+            $route->withoutScopedBindings();
         }
     }
 


### PR DESCRIPTION
When explicitly setting the value of the attribute `ScopeBindings` to false as shown in the example below, the `RouteRegistrar` doesn't actually call `withoutScopedBindings`, resulting in the default Laravel behavior. In most cases, this is without scoped bindings and thus correct, but in the following example, it should be completely disabled:

```php
<?php

namespace App\Http\Controllers\Web;

use App\Models\Pokemon\PokemonEncounter;
use App\Models\Pokemon\PokemonTrade;
use Illuminate\Http\RedirectResponse;
use Illuminate\Routing\Controller;
use Spatie\RouteAttributes\Attributes\Put;
use Spatie\RouteAttributes\Attributes\ScopeBindings;

class PoketradeController extends Controller
{
    #[ScopeBindings(false)]
    #[Put('/trades/{trade:uuid}/select/{encounter:uuid?}', 'poketrade.select')]
    public function select(PokemonTrade $trade, ?PokemonEncounter $encounter = null): RedirectResponse
    {
        // ...
    }
}
```

[The Laravel docs](https://laravel.com/docs/10.x/routing#implicit-model-binding-scoping) state the following:
> When using a custom keyed implicit binding as a nested route parameter, Laravel will automatically scope the query to retrieve the nested model by its parent using conventions to guess the relationship name on the parent.

Without this fix, navigating to this route will result in the following exception:
> BadMethodCallException: Call to undefined method App\Models\Pokemon\PokemonTrade::encounters()