### PR TITLE
Add WithoutMiddleware option to route

### DIFF
--- a/src/Attributes/Any.php
+++ b/src/Attributes/Any.php
@@ -12,12 +12,14 @@ class Any extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        array | string $withoutMiddleware = [],
     ) {
         parent::__construct(
             methods: Router::$verbs,
             uri: $uri,
             name: $name,
             middleware: $middleware,
+            withoutMiddleware: $withoutMiddleware
         );
     }
 }

--- a/src/Attributes/Delete.php
+++ b/src/Attributes/Delete.php
@@ -11,12 +11,14 @@ class Delete extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        array | string $withoutMiddleware = [],
     ) {
         parent::__construct(
             methods: ['delete'],
             uri: $uri,
             name: $name,
             middleware: $middleware,
+            withoutMiddleware: $withoutMiddleware
         );
     }
 }

--- a/src/Attributes/Get.php
+++ b/src/Attributes/Get.php
@@ -11,12 +11,14 @@ class Get extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        array | string $withoutMiddleware = [],
     ) {
         parent::__construct(
             methods: ['get'],
             uri: $uri,
             name: $name,
             middleware: $middleware,
+            withoutMiddleware: $withoutMiddleware
         );
     }
 }

--- a/src/Attributes/Patch.php
+++ b/src/Attributes/Patch.php
@@ -11,12 +11,14 @@ class Patch extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        array | string $withoutMiddleware = [],
     ) {
         parent::__construct(
             methods: ['patch'],
             uri: $uri,
             name: $name,
             middleware: $middleware,
+            withoutMiddleware: $withoutMiddleware
         );
     }
 }

--- a/src/Attributes/Post.php
+++ b/src/Attributes/Post.php
@@ -11,12 +11,14 @@ class Post extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        array | string $withoutMiddleware = [],
     ) {
         parent::__construct(
             methods: ['post'],
             uri: $uri,
             name: $name,
             middleware: $middleware,
+            withoutMiddleware: $withoutMiddleware
         );
     }
 }

--- a/src/Attributes/Put.php
+++ b/src/Attributes/Put.php
@@ -11,12 +11,14 @@ class Put extends Route
         string $uri,
         ?string $name = null,
         array | string $middleware = [],
+        array | string $withoutMiddleware = [],
     ) {
         parent::__construct(
             methods: ['put'],
             uri: $uri,
             name: $name,
             middleware: $middleware,
+            withoutMiddleware: $withoutMiddleware
         );
     }
 }

--- a/src/Attributes/Route.php
+++ b/src/Attributes/Route.php
@@ -13,11 +13,14 @@ class Route implements RouteAttribute
 
     public array $middleware;
 
+    public array $withoutMiddleware;
+
     public function __construct(
         array | string $methods,
         public string $uri,
         public ?string $name = null,
         array | string $middleware = [],
+        array | string $withoutMiddleware = [],
     ) {
         $this->methods = array_map(
             static fn (string $verb) => in_array(
@@ -29,5 +32,6 @@ class Route implements RouteAttribute
             Arr::wrap($methods)
         );
         $this->middleware = Arr::wrap($middleware);
+        $this->withoutMiddleware = Arr::wrap($withoutMiddleware);
     }
 }

--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -116,19 +116,19 @@ class RouteRegistrar
         $class = new ReflectionClass($className);
 
         $classRouteAttributes = new ClassRouteAttributes($class);
-        
+
         $groups = $classRouteAttributes->groups();
-        
+
         foreach ($groups as $group) {
             $router = $this->router;
             $router->group($group, fn () => $this->registerRoutes($class, $classRouteAttributes));
         }
-        
+
         if ($classRouteAttributes->resource()) {
             $this->registerResource($class, $classRouteAttributes);
         }
 
-       
+
     }
 
     protected function registerResource(ReflectionClass $class, ClassRouteAttributes $classRouteAttributes): void
@@ -173,6 +173,9 @@ class RouteRegistrar
 
 
                 $this->addMiddlewareToRoute($classRouteAttributes, $attributeClass, $route);
+
+                $this->addWithoutMiddlewareToRoute($classRouteAttributes, $attributeClass, $route);
+
 
                 $this->setWithTrashedIfAvailable($classRouteAttributes, $withTrashedAttribute, $route);
 
@@ -262,6 +265,18 @@ class RouteRegistrar
         $classMiddleware = $classRouteAttributes->middleware();
         $methodMiddleware = $attributeClass->middleware;
         $route->middleware([...$this->middleware, ...$classMiddleware, ...$methodMiddleware]);
+    }
+
+    /**
+     * @param ClassRouteAttributes $classRouteAttributes
+     * @param Route $attributeClass
+     * @param \Illuminate\Routing\Route $route
+     * @return void
+     */
+    private function addWithoutMiddlewareToRoute(ClassRouteAttributes $classRouteAttributes, Route $attributeClass, \Illuminate\Routing\Route $route): void
+    {
+        $methodWithoutMiddleware = $attributeClass->withoutMiddleware;
+        $route->withoutMiddleware($methodWithoutMiddleware);
     }
 
     /**

--- a/tests/AttributeTests/FallbackAttributeTest.php
+++ b/tests/AttributeTests/FallbackAttributeTest.php
@@ -14,6 +14,12 @@ class FallbackAttributeTest extends TestCase
 
         $this
             ->assertRegisteredRoutesCount(1)
-            ->assertRouteRegistered(FallbackTestController::class, 'myFallbackMethod', 'get', 'my-fallback-method', [], null, null, [], true);
+            ->assertRouteRegistered(
+                controller: FallbackTestController::class,
+                controllerMethod: 'myFallbackMethod',
+                httpMethods: 'get',
+                uri: 'my-fallback-method',
+                isFallback: true
+            );
     }
 }

--- a/tests/AttributeTests/WithoutMiddlewareAttributeTest.php
+++ b/tests/AttributeTests/WithoutMiddlewareAttributeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\AttributeTests;
+
+use Spatie\RouteAttributes\Tests\TestCase;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\WithoutMiddlewareTestController;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\SkippedMiddleware;
+
+class WithoutMiddlewareAttributeTest extends TestCase
+{
+    /** @test */
+    public function it_can_skip_middleware_added_to_class()
+    {
+        $this->routeRegistrar->registerClass(WithoutMiddlewareTestController::class);
+
+
+        $this
+            ->assertRegisteredRoutesCount(1)
+            ->assertRouteRegistered(
+                WithoutMiddlewareTestController::class,
+                controllerMethod: 'withoutMiddleware',
+                uri: 'without-middleware',
+                withoutMiddleware: [SkippedMiddleware::class],
+            );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,28 +40,34 @@ class TestCase extends Orchestra
     }
 
     public function assertRouteRegistered(
-        string $controller,
-        string $controllerMethod = 'myMethod',
-        string | array $httpMethods = ['get'],
-        string $uri = 'my-method',
-        string | array $middleware = [],
-        ?string $name = null,
-        ?string $domain = null,
-        ?array $wheres = [],
-        ?bool $isFallback = false,
-        ?bool $enforcesScopedBindings = false,
-        ?bool $preventsScopedBindings = false,
-        ?array $defaults = [],
-        ?bool $withTrashed = false,
-    ): self {
-        if (! is_array($middleware)) {
+        string       $controller,
+        string       $controllerMethod = 'myMethod',
+        string|array $httpMethods = ['get'],
+        string       $uri = 'my-method',
+        string|array $middleware = [],
+        string|array $withoutMiddleware = [],
+        ?string      $name = null,
+        ?string      $domain = null,
+        ?array       $wheres = [],
+        ?bool        $isFallback = false,
+        ?bool        $enforcesScopedBindings = false,
+        ?bool        $preventsScopedBindings = false,
+        ?array       $defaults = [],
+        ?bool        $withTrashed = false,
+    ): self
+    {
+        if (!is_array($middleware)) {
             $middleware = Arr::wrap($middleware);
         }
 
+        if (!is_array($withoutMiddleware)) {
+            $withoutMiddleware = Arr::wrap($withoutMiddleware);
+        }
+
         $routeRegistered = collect($this->getRouteCollection()->getRoutes())
-            ->contains(function (Route $route) use ($name, $middleware, $controllerMethod, $controller, $uri, $httpMethods, $domain, $wheres, $isFallback, $enforcesScopedBindings, $preventsScopedBindings, $defaults, $withTrashed) {
+            ->contains(function (Route $route) use ($name, $middleware, $withoutMiddleware, $controllerMethod, $controller, $uri, $httpMethods, $domain, $wheres, $isFallback, $enforcesScopedBindings, $preventsScopedBindings, $defaults, $withTrashed) {
                 foreach (Arr::wrap($httpMethods) as $httpMethod) {
-                    if (! in_array(strtoupper($httpMethod), $route->methods)) {
+                    if (!in_array(strtoupper($httpMethod), $route->methods)) {
                         return false;
                     }
                 }
@@ -81,6 +87,10 @@ class TestCase extends Orchestra
                 }
 
                 if (array_diff(array_merge($middleware, $this->routeRegistrar->middleware()), $route->middleware())) {
+                    return false;
+                }
+
+                if (array_diff($withoutMiddleware, $route->excludedMiddleware())) {
                     return false;
                 }
 

--- a/tests/TestClasses/Controllers/WithoutMiddlewareTestController.php
+++ b/tests/TestClasses/Controllers/WithoutMiddlewareTestController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers;
+
+use Spatie\RouteAttributes\Attributes\Route;
+use Spatie\RouteAttributes\Tests\TestClasses\Middleware\SkippedMiddleware;
+
+class WithoutMiddlewareTestController
+{
+    #[Route('get', 'without-middleware', withoutMiddleware: SkippedMiddleware::class)]
+    public function withoutMiddleware()
+    {
+    }
+}

--- a/tests/TestClasses/Middleware/SkippedMiddleware.php
+++ b/tests/TestClasses/Middleware/SkippedMiddleware.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class SkippedMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Added missing option to define a `withoutMiddleware` when defining single route.

Also have changed [FallbackAttributeTest.php](https://github.com/spatie/laravel-route-attributes/compare/main...mikield:laravel-route-attributes:main?expand=1#diff-dc079cffa691d8a9e5372f3c5ee5ccaef15b9ceb2d9699a69560fb7f64f81326) to use named arguments when calling assertion, to avoid parameters mismatch error.