### PR TITLE
Make Prefix attribute repeatable

### DIFF
--- a/src/Attributes/Prefix.php
+++ b/src/Attributes/Prefix.php
@@ -4,7 +4,7 @@ namespace Spatie\RouteAttributes\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_CLASS)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class Prefix implements RouteAttribute
 {
     public function __construct(

--- a/src/ClassRouteAttributes.php
+++ b/src/ClassRouteAttributes.php
@@ -25,14 +25,18 @@ class ClassRouteAttributes
     /**
      * @psalm-suppress NoInterfaceProperties
      */
-    public function prefix(): ?string
+    public function prefix(): array
     {
-        /** @var Prefix $attribute */
-        if (! $attribute = $this->getAttribute(Prefix::class)) {
-            return null;
+        $prefixes = [];
+
+        /** @var ReflectionClass[] $attributes */
+        $attributes = $this->class->getAttributes(Prefix::class, \ReflectionAttribute::IS_INSTANCEOF);
+        foreach ($attributes as $attribute) {
+            $attributeClass = $attribute->newInstance();
+            $prefixes[] = $attributeClass->prefix;
         }
 
-        return $attribute->prefix;
+        return $prefixes;
     }
 
     /**
@@ -81,10 +85,13 @@ class ClassRouteAttributes
                 ]);
             }
         } else {
-            $groups[] = array_filter([
-                'domain' => $this->domainFromConfig() ?? $this->domain(),
-                'prefix' => $this->prefix(),
-            ]);
+            $prefixes = $this->prefix();
+            foreach ($prefixes as $prefix) {
+                $groups[] = array_filter([
+                    'domain' => $this->domainFromConfig() ?? $this->domain(),
+                    'prefix' => $prefix,
+                ]);
+            }
         }
 
         return $groups;

--- a/tests/AttributeTests/PrefixAttributeTest.php
+++ b/tests/AttributeTests/PrefixAttributeTest.php
@@ -31,4 +31,45 @@ class PrefixAttributeTest extends TestCase
                 uri: 'my-prefix/my-post-method',
             );
     }
+
+    /** @test */
+    public function it_can_apply_multiple_prefixes_on_the_url_of_every_method()
+    {
+        $this->routeRegistrar->registerClass(PrefixTestController::class);
+
+        $this
+            ->assertRegisteredRoutesCount(6)
+            ->assertRouteRegistered(
+                PrefixTestController::class,
+                controllerMethod: 'myRootGetMethod',
+                uri: 'my-prefix',
+            )
+            ->assertRouteRegistered(
+                PrefixTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-prefix/my-get-method',
+            )
+            ->assertRouteRegistered(
+                PrefixTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethods: 'post',
+                uri: 'my-prefix/my-post-method',
+            )
+            ->assertRouteRegistered(
+                PrefixTestController::class,
+                controllerMethod: 'myRootGetMethod',
+                uri: 'my-second-prefix',
+            )
+            ->assertRouteRegistered(
+                PrefixTestController::class,
+                controllerMethod: 'myGetMethod',
+                uri: 'my-second-prefix/my-get-method',
+            )
+            ->assertRouteRegistered(
+                PrefixTestController::class,
+                controllerMethod: 'myPostMethod',
+                httpMethods: 'post',
+                uri: 'my-second-prefix/my-post-method',
+            );
+    }
 }

--- a/tests/TestClasses/Controllers/PrefixTestController.php
+++ b/tests/TestClasses/Controllers/PrefixTestController.php
@@ -7,6 +7,7 @@ use Spatie\RouteAttributes\Attributes\Post;
 use Spatie\RouteAttributes\Attributes\Prefix;
 
 #[Prefix('my-prefix')]
+#[Prefix('my-second-prefix')]
 class PrefixTestController
 {
     #[Get('/')]


### PR DESCRIPTION
Mark the `Prefix` attribute as repeatable and update the `ClassRouteAttributes` class to support multiple prefixes.

* **Prefix Attribute**:
  - Mark the `Prefix` attribute in `src/Attributes/Prefix.php` as repeatable by adding `Attribute::IS_REPEATABLE`.

* **ClassRouteAttributes**:
  - Update the `prefix` method in `src/ClassRouteAttributes.php` to return an array of prefixes.
  - Update the `groups` method in `src/ClassRouteAttributes.php` to handle multiple prefixes.

* **Tests**:
  - Add a test for multiple prefixes in `tests/AttributeTests/PrefixAttributeTest.php`.
  - Add multiple `Prefix` attributes to the `PrefixTestController` class in `tests/TestClasses/Controllers/PrefixTestController.php`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spatie/laravel-route-attributes/pull/152?shareId=a2fdd404-d883-436b-a919-760bdaff2450).