### PR TITLE
Create RouteRegistrar with DI instead of literal instantiation

### DIFF
--- a/src/RouteAttributesServiceProvider.php
+++ b/src/RouteAttributesServiceProvider.php
@@ -29,7 +29,7 @@ class RouteAttributesServiceProvider extends ServiceProvider
             return;
         }
 
-        $routeRegistrar = (new RouteRegistrar(app()->router))
+        $routeRegistrar = $this->app->make(RouteRegistrar::class, [app()->router])
             ->useMiddleware(config('route-attributes.middleware') ?? []);
 
         collect($this->getRouteDirectories())->each(function (string|array $directory, string|int $namespace) use ($routeRegistrar) {


### PR DESCRIPTION
It helps with tweaking `RouteRegistrar` in the case of an unorthodox directory structure

My use case for tweaking `RouteRegistrar`  was changing it like this:

```php
    public function useBasePath(string $basePath): self {
        // Wrapped in realpath()
        $this->basePath = realpath(str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $basePath));

        return $this;
    }

```

which allows using `..` in directory names, but it also resolves symlinks, so I don't suggest this change as another PR to fix the underlying problem, as a proper fix would be quite verbose and I don't really care to commit to this further, but I would be happy if it was incorporated in the library as well.