### PR TITLE
Fix: Missing resource controller defined by groups

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -109,7 +109,12 @@ class RouteRegistrar
     {
         $this->router->group(
             $item['group'],
-            fn () => $this->registerRoutes($item['class'], $item['classRouteAttributes'])
+            function () use ($item) {
+                $this->registerRoutes($item['class'], $item['classRouteAttributes']);
+                if ($item['classRouteAttributes']->resource()) {
+                    $this->registerResource($item['class'], $item['classRouteAttributes']);
+                }
+            }
         );
     }
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -4,6 +4,7 @@ namespace Spatie\RouteAttributes\Tests;
 
 use Spatie\RouteAttributes\RouteAttributesServiceProvider;
 use Spatie\RouteAttributes\RouteRegistrar;
+use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Grouped\GroupResourceTestController;
 use Spatie\RouteAttributes\Tests\TestClasses\Controllers\Grouped\GroupTestController;
 
 class ServiceProviderTest extends TestCase
@@ -37,7 +38,7 @@ class ServiceProviderTest extends TestCase
 
     public function test_the_provider_can_register_group_of_directories(): void
     {
-        $this->expectRegisteredRoutesCount(2);
+        $this->expectRegisteredRoutesCount(7);
 
         $this->expectRouteRegistered(
             GroupTestController::class,
@@ -52,6 +53,51 @@ class ServiceProviderTest extends TestCase
             httpMethods: 'post',
             uri: 'grouped/my-post-method',
             middleware: ['SomeMiddleware', 'api']
+        );
+
+        $this->expectRouteRegistered(
+            GroupResourceTestController::class,
+            controllerMethod: 'index',
+            httpMethods: 'get',
+            uri: 'grouped/posts',
+            middleware: ['api'],
+            name: 'posts.index'
+        );
+
+        $this->expectRouteRegistered(
+            GroupResourceTestController::class,
+            controllerMethod: 'store',
+            httpMethods: 'post',
+            uri: 'grouped/posts',
+            middleware: ['api'],
+            name: 'posts.store'
+        );
+
+        $this->expectRouteRegistered(
+            GroupResourceTestController::class,
+            controllerMethod: 'show',
+            httpMethods: 'get',
+            uri: 'grouped/posts/{post}',
+            middleware: ['api'],
+            name: 'posts.show'
+        );
+
+        $this->expectRouteRegistered(
+            GroupResourceTestController::class,
+            controllerMethod: 'update',
+            httpMethods: 'put',
+            uri: 'grouped/posts/{post}',
+            middleware: ['api'],
+            name: 'posts.update'
+        );
+
+        $this->expectRouteRegistered(
+            GroupResourceTestController::class,
+            controllerMethod: 'destroy',
+            httpMethods: 'delete',
+            uri: 'grouped/posts/{post}',
+            middleware: ['api'],
+            name: 'posts.destroy'
         );
     }
 }

--- a/tests/TestClasses/Controllers/Grouped/GroupResourceTestController.php
+++ b/tests/TestClasses/Controllers/Grouped/GroupResourceTestController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\RouteAttributes\Tests\TestClasses\Controllers\Grouped;
+
+use Illuminate\Http\Request;
+use Spatie\RouteAttributes\Attributes\ApiResource;
+
+#[ApiResource('posts')]
+class GroupResourceTestController
+{
+    public function index() {}
+
+    public function store(Request $request) {}
+
+    public function show($id) {}
+
+    public function update(Request $request, $id) {}
+
+    public function destroy($id) {}
+}


### PR DESCRIPTION
Starting with the 1.26 release, resource controller that are defined by a group are missing. The reason is that the `registerDirectory` uses in the previous  versions the processAttributes ( by using `registerFile`). With the latest changes thats not the case any more. For that the `registerResource` is not called any more for routes that are defined by groups.