### PR TITLE
Prevent duplicated prefix on grouped resource routes

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -109,7 +109,7 @@ class RouteRegistrar
     {
         $this->router->group(
             $item['group'],
-            fn() => $this->registerRoutes($item['class'], $item['classRouteAttributes'])
+            fn () => $this->registerRoutes($item['class'], $item['classRouteAttributes'])
         );
 
         if ($item['classRouteAttributes']->resource()) {

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -62,7 +62,7 @@ class ServiceProviderTest extends TestCase
             controllerMethod: 'index',
             httpMethods: 'get',
             uri: 'grouped/posts',
-            middleware: ['SomeMiddleware','api'],
+            middleware: ['SomeMiddleware', 'api'],
             name: 'posts.index'
         );
 
@@ -71,7 +71,7 @@ class ServiceProviderTest extends TestCase
             controllerMethod: 'store',
             httpMethods: 'post',
             uri: 'grouped/posts',
-            middleware: ['SomeMiddleware','api'],
+            middleware: ['SomeMiddleware', 'api'],
             name: 'posts.store'
         );
 
@@ -80,7 +80,7 @@ class ServiceProviderTest extends TestCase
             controllerMethod: 'show',
             httpMethods: 'get',
             uri: 'grouped/posts/{post}',
-            middleware: ['SomeMiddleware','api'],
+            middleware: ['SomeMiddleware', 'api'],
             name: 'posts.show'
         );
 
@@ -89,7 +89,7 @@ class ServiceProviderTest extends TestCase
             controllerMethod: 'update',
             httpMethods: 'put',
             uri: 'grouped/posts/{post}',
-            middleware: ['SomeMiddleware','api'],
+            middleware: ['SomeMiddleware', 'api'],
             name: 'posts.update'
         );
 
@@ -98,7 +98,7 @@ class ServiceProviderTest extends TestCase
             controllerMethod: 'destroy',
             httpMethods: 'delete',
             uri: 'grouped/posts/{post}',
-            middleware: ['SomeMiddleware','api'],
+            middleware: ['SomeMiddleware', 'api'],
             name: 'posts.destroy'
         );
 
@@ -107,7 +107,7 @@ class ServiceProviderTest extends TestCase
             controllerMethod: 'index',
             httpMethods: 'get',
             uri: 'grouped/api/v1/my-prefix/etc/posts',
-            middleware: ['SomeMiddleware','api'],
+            middleware: ['SomeMiddleware', 'api'],
             name: 'prefixed_posts.index'
         );
 
@@ -116,7 +116,7 @@ class ServiceProviderTest extends TestCase
             controllerMethod: 'show',
             httpMethods: 'get',
             uri: 'grouped/api/v1/my-prefix/etc/posts/{post}',
-            middleware: ['SomeMiddleware','api'],
+            middleware: ['SomeMiddleware', 'api'],
             name: 'prefixed_posts.show'
         );
 
@@ -125,7 +125,7 @@ class ServiceProviderTest extends TestCase
             controllerMethod: 'myGetMethod',
             httpMethods: 'get',
             uri: 'grouped/my-prefix/my-prefix-get-method',
-            middleware: ['SomeMiddleware','api'],
+            middleware: ['SomeMiddleware', 'api'],
         );
 
         $this->expectRouteRegistered(
@@ -133,7 +133,7 @@ class ServiceProviderTest extends TestCase
             controllerMethod: 'myPostMethod',
             httpMethods: 'post',
             uri: 'grouped/my-prefix/my-prefix-post-method',
-            middleware: ['SomeMiddleware','api'],
+            middleware: ['SomeMiddleware', 'api'],
         );
     }
 }

--- a/tests/TestClasses/Controllers/Grouped/GroupPrefixTestController.php
+++ b/tests/TestClasses/Controllers/Grouped/GroupPrefixTestController.php
@@ -10,12 +10,8 @@ use Spatie\RouteAttributes\Attributes\Prefix;
 class GroupPrefixTestController
 {
     #[Get('my-prefix-get-method')]
-    public function myGetMethod()
-    {
-    }
+    public function myGetMethod() {}
 
     #[Post('my-prefix-post-method')]
-    public function myPostMethod()
-    {
-    }
+    public function myPostMethod() {}
 }

--- a/tests/TestClasses/Controllers/Grouped/GroupResourceTestPrefixController.php
+++ b/tests/TestClasses/Controllers/Grouped/GroupResourceTestPrefixController.php
@@ -9,11 +9,7 @@ use Spatie\RouteAttributes\Attributes\Resource;
 #[Resource('posts', only: ['index', 'show'], names: 'prefixed_posts')]
 class GroupResourceTestPrefixController
 {
-    public function index()
-    {
-    }
+    public function index() {}
 
-    public function show($id)
-    {
-    }
+    public function show($id) {}
 }


### PR DESCRIPTION
In the pull request from yesterday #173, was a next issue included. The registration of resource routes should not be done in the group. The result is a duplicated prefix for the uris.

Instead of `grouped/api/v1/my-prefix/etc/posts` the uri is `grouped/api/v1/my-prefix/etc/posts` , if the definition is prefixed by group and prefix attribute.